### PR TITLE
feat: 支持 TUI 创建和自定义 App 打开器

### DIFF
--- a/.modu.example.yaml
+++ b/.modu.example.yaml
@@ -10,6 +10,23 @@ strict-dirty-check: true
 #   - frontend
 #   - backend
 
+# TUI 操作菜单自定义打开工具（可选）
+# - name: 稳定名称，必填
+# - app: macOS open -a 可识别的 App 名称，必填；启动时用 open -Ra 判断是否已安装
+# - label: 菜单展示名，可选；为空时使用 app
+# - shortcut: 操作菜单快捷键，可选；必须是单个可打印字符
+# 未安装的 App 不展示；快捷键与内置项冲突时，该 App 仍展示，但不显示也不绑定快捷键
+app-openers:
+  - name: zed
+    app: Zed
+    label: Zed
+    shortcut: z
+  # 示例：如果 c 与内置“复制路径”冲突，菜单仍显示 Cursor，但不显示 "(c)"
+  - name: cursor
+    app: Cursor
+    label: Cursor
+    shortcut: c
+
 modules:
   - name: frontend
     url: git@github.com:example/frontend.git

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.25.8
+golang 1.25.8 system

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ modules:
     url: https://github.com/example/frontend.git
   - name: backend
     url: https://github.com/example/backend.git
+
+app-openers:
+  - name: zed
+    app: Zed
+    label: Zed
+    shortcut: z
 ```
 
 **配置项说明：**
@@ -57,6 +63,7 @@ modules:
 | `auto-fetch`             | 否   | 操作前自动 fetch          |
 | `strict-dirty-check`     | 否   | 删除前强制脏检查          |
 | `default-selected-modules` | 否   | 创建 feature 时默认选中的模块列表（可通过 `modu default-select` 命令配置） |
+| `app-openers`           | 否   | TUI 操作菜单中的自定义打开工具 |
 | `modules`               | 是   | 模块列表                  |
 
 **模块配置：**
@@ -66,6 +73,17 @@ modules:
 | `name`        | 是   | 模块名称         |
 | `url`         | 是   | Git 仓库地址     |
 | `base-branch` | 否   | 覆盖全局默认分支 |
+
+**App opener 配置：**
+
+| 字段       | 必填 | 说明                                      |
+| ---------- | ---- | ----------------------------------------- |
+| `name`     | 是   | 稳定名称，例如 `zed`                      |
+| `app`      | 是   | macOS `open -a` 可识别的 App 名称         |
+| `label`    | 否   | 菜单展示名，空时使用 `app`                |
+| `shortcut` | 否   | 操作菜单快捷键，必须是单个可打印字符      |
+
+TUI 启动时会检测 `app` 是否已安装；未安装的工具不会出现在操作菜单中。若 `shortcut` 与内置快捷键冲突，菜单仍显示该工具，但不展示也不绑定该快捷键。
 
 **环境变量：**
 
@@ -150,6 +168,7 @@ modu config scan --module "backend=..."       # 扫描并添加模块
 
 # 查看版本信息
 modu version
+```
 
 ### TUI 快捷键
 
@@ -157,13 +176,19 @@ modu version
 | ------ | ------------------------------- |
 | ↑/↓    | 上下选择 feature                 |
 | Enter  | 回车确认                        |
+| n      | 新建 feature                    |
 | c      | 复制路径到剪贴板                 |
 | d      | 删除选中 feature                 |
 | m      | 管理模块（仅 feature 有效）      |
 | o      | 用 VS Code 打开主项目           |
+| x      | 用 Codex 打开主项目             |
+| z      | 用配置的 Zed 打开主项目（示例） |
 | u      | 更新代码                         |
 | q/esc  | 退出 TUI                       |
 
+配置化 App opener 只在对应 App 已安装时显示；快捷键冲突时可通过操作菜单选中后按 Enter 执行。
+
+```bash
 # 创建配置文件
 modu config create
 modu config create --module "frontend=git@github.com:example/frontend.git"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ app-openers:
 | 字段       | 必填 | 说明                                      |
 | ---------- | ---- | ----------------------------------------- |
 | `name`     | 是   | 稳定名称，例如 `zed`                      |
-| `app`      | 是   | macOS `open -a` 可识别的 App 名称         |
+| `app`      | 是   | macOS“应用程序”中的 App 名称，例如 VS Code 应填 `Visual Studio Code`，而不是 `vscode` 或 CLI 命令 `code` |
 | `label`    | 否   | 菜单展示名，空时使用 `app`                |
 | `shortcut` | 否   | 操作菜单快捷键，必须是单个可打印字符      |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	errs "github.com/qimaotech/modu/internal/errors"
 	"gopkg.in/yaml.v3"
@@ -15,14 +17,15 @@ import (
 
 // Config modu 配置文件结构
 type Config struct {
-	Workspace             string   `yaml:"workspace"`                // 裸仓库/主仓库所在目录
-	WorktreeRoot          string   `yaml:"worktree-root"`             // 特性分支代码存放目录
-	DefaultBase           string   `yaml:"default-base"`             // 默认基准分支 (如 develop)
-	Concurrency           int      `yaml:"concurrency"`              // 并发数，默认 5
-	AutoFetch             bool     `yaml:"auto-fetch"`               // 操作前自动 fetch
-	StrictDirty           bool     `yaml:"strict-dirty-check"`       // 删除前强制脏检查
-	Modules               []Module `yaml:"modules"`                  // 模块列表
-	DefaultSelectedModules []string `yaml:"default-selected-modules"` // 创建时默认选中的模块列表
+	Workspace              string      `yaml:"workspace"`                // 裸仓库/主仓库所在目录
+	WorktreeRoot           string      `yaml:"worktree-root"`            // 特性分支代码存放目录
+	DefaultBase            string      `yaml:"default-base"`             // 默认基准分支 (如 develop)
+	Concurrency            int         `yaml:"concurrency"`              // 并发数，默认 5
+	AutoFetch              bool        `yaml:"auto-fetch"`               // 操作前自动 fetch
+	StrictDirty            bool        `yaml:"strict-dirty-check"`       // 删除前强制脏检查
+	Modules                []Module    `yaml:"modules"`                  // 模块列表
+	DefaultSelectedModules []string    `yaml:"default-selected-modules"` // 创建时默认选中的模块列表
+	AppOpeners             []AppOpener `yaml:"app-openers,omitempty"`    // TUI 操作菜单额外打开工具
 }
 
 // IsConfigNotFoundError 检查是否为配置文件不存在错误
@@ -43,6 +46,14 @@ type Module struct {
 	Name       string `yaml:"name"`                  // 模块名称
 	URL        string `yaml:"url"`                   // 仓库 URL
 	BaseBranch string `yaml:"base-branch,omitempty"` // 可选，覆盖全局设置
+}
+
+// AppOpener TUI 操作菜单中可配置的外部 App 打开工具
+type AppOpener struct {
+	Name     string `yaml:"name"`               // 稳定名称，用于区分配置项
+	App      string `yaml:"app"`                // 系统 App 名称，例如 Zed、Cursor
+	Label    string `yaml:"label,omitempty"`    // 菜单展示名，空时使用 App
+	Shortcut string `yaml:"shortcut,omitempty"` // 可选单字符快捷键
 }
 
 // LoadConfig 加载并校验配置文件
@@ -169,6 +180,7 @@ func validate(cfg *Config) error {
 	if len(cfg.Modules) == 0 {
 		validationErrs = append(validationErrs, fmt.Errorf("%w: at least one module is required", errs.ErrConfigInvalid))
 	}
+	validationErrs = append(validationErrs, validateAppOpeners(cfg)...)
 	return errors.Join(validationErrs...)
 }
 
@@ -184,7 +196,34 @@ func validateBasic(cfg *Config) error {
 	if cfg.DefaultBase == "" {
 		validationErrs = append(validationErrs, fmt.Errorf("%w: default-base is required", errs.ErrConfigInvalid))
 	}
+	validationErrs = append(validationErrs, validateAppOpeners(cfg)...)
 	return errors.Join(validationErrs...)
+}
+
+func validateAppOpeners(cfg *Config) []error {
+	var validationErrs []error
+	for i, opener := range cfg.AppOpeners {
+		prefix := fmt.Sprintf("app-openers[%d]", i)
+		if strings.TrimSpace(opener.Name) == "" {
+			validationErrs = append(validationErrs, fmt.Errorf("%w: %s.name is required", errs.ErrConfigInvalid, prefix))
+		}
+		if strings.TrimSpace(opener.App) == "" {
+			validationErrs = append(validationErrs, fmt.Errorf("%w: %s.app is required", errs.ErrConfigInvalid, prefix))
+		}
+		if opener.Shortcut == "" {
+			continue
+		}
+		if utf8.RuneCountInString(opener.Shortcut) != 1 {
+			validationErrs = append(validationErrs, fmt.Errorf("%w: %s.shortcut must be a single printable key", errs.ErrConfigInvalid, prefix))
+			continue
+		}
+		for _, r := range opener.Shortcut {
+			if !unicode.IsPrint(r) || unicode.IsSpace(r) {
+				validationErrs = append(validationErrs, fmt.Errorf("%w: %s.shortcut must be a single printable key", errs.ErrConfigInvalid, prefix))
+			}
+		}
+	}
+	return validationErrs
 }
 
 // DefaultConfig 返回默认配置模板

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -152,6 +152,172 @@ modules:
 	}
 }
 
+func TestLoadConfig_AppOpeners(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		assert  func(t *testing.T, cfg *Config)
+	}{
+		{
+			name: "zed opener example",
+			content: `workspace: /opt/workspace
+worktree-root: /opt/worktrees
+default-base: develop
+modules:
+  - name: auth-svc
+    url: git@github.com:example/auth-svc.git
+app-openers:
+  - name: zed
+    app: Zed
+    label: Zed
+    shortcut: z
+`,
+			assert: func(t *testing.T, cfg *Config) {
+				t.Helper()
+				if len(cfg.AppOpeners) != 1 {
+					t.Fatalf("expected 1 app opener, got %d", len(cfg.AppOpeners))
+				}
+				opener := cfg.AppOpeners[0]
+				if opener.Name != "zed" || opener.App != "Zed" || opener.Label != "Zed" || opener.Shortcut != "z" {
+					t.Fatalf("unexpected opener: %+v", opener)
+				}
+			},
+		},
+		{
+			name: "missing app openers remains compatible",
+			content: `workspace: /opt/workspace
+worktree-root: /opt/worktrees
+default-base: develop
+modules:
+  - name: auth-svc
+    url: git@github.com:example/auth-svc.git
+`,
+			assert: func(t *testing.T, cfg *Config) {
+				t.Helper()
+				if len(cfg.AppOpeners) != 0 {
+					t.Fatalf("expected no app openers, got %d", len(cfg.AppOpeners))
+				}
+			},
+		},
+		{
+			name: "opener without shortcut",
+			content: `workspace: /opt/workspace
+worktree-root: /opt/worktrees
+default-base: develop
+modules:
+  - name: auth-svc
+    url: git@github.com:example/auth-svc.git
+app-openers:
+  - name: cursor
+    app: Cursor
+`,
+			assert: func(t *testing.T, cfg *Config) {
+				t.Helper()
+				if len(cfg.AppOpeners) != 1 {
+					t.Fatalf("expected 1 app opener, got %d", len(cfg.AppOpeners))
+				}
+				if cfg.AppOpeners[0].Shortcut != "" {
+					t.Fatalf("expected empty shortcut, got %q", cfg.AppOpeners[0].Shortcut)
+				}
+			},
+		},
+		{
+			name: "shortcut conflict loads",
+			content: `workspace: /opt/workspace
+worktree-root: /opt/worktrees
+default-base: develop
+modules:
+  - name: auth-svc
+    url: git@github.com:example/auth-svc.git
+app-openers:
+  - name: cursor
+    app: Cursor
+    shortcut: c
+`,
+			assert: func(t *testing.T, cfg *Config) {
+				t.Helper()
+				if len(cfg.AppOpeners) != 1 || cfg.AppOpeners[0].Shortcut != "c" {
+					t.Fatalf("expected conflicting shortcut to load for TUI resolution, got %+v", cfg.AppOpeners)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, ".modu.yaml")
+			if err := os.WriteFile(configPath, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("failed to write test config: %v", err)
+			}
+
+			cfg, err := LoadConfig(configPath)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.assert(t, cfg)
+		})
+	}
+}
+
+func TestLoadConfig_AppOpenersValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		openerYAML  string
+		errContains string
+	}{
+		{
+			name: "missing opener name",
+			openerYAML: `  - app: Zed
+    shortcut: z
+`,
+			errContains: "name is required",
+		},
+		{
+			name: "missing app name",
+			openerYAML: `  - name: zed
+    shortcut: z
+`,
+			errContains: "app is required",
+		},
+		{
+			name: "shortcut has multiple characters",
+			openerYAML: `  - name: zed
+    app: Zed
+    shortcut: zz
+`,
+			errContains: "shortcut",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, ".modu.yaml")
+			content := `workspace: /opt/workspace
+worktree-root: /opt/worktrees
+default-base: develop
+modules:
+  - name: auth-svc
+    url: git@github.com:example/auth-svc.git
+app-openers:
+` + tt.openerYAML
+
+			if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+				t.Fatalf("failed to write test config: %v", err)
+			}
+
+			_, err := LoadConfig(configPath)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr))
 }
@@ -201,7 +367,7 @@ func TestSaveConfig(t *testing.T) {
 		Workspace:    "/test/workspace",
 		WorktreeRoot: "/test/worktrees",
 		DefaultBase:  "main",
-		Concurrency: 3,
+		Concurrency:  3,
 		AutoFetch:    false,
 		StrictDirty:  false,
 		Modules: []Module{
@@ -248,7 +414,7 @@ func TestSaveConfig_InvalidPath(t *testing.T) {
 		Workspace:    "/test",
 		WorktreeRoot: "/test",
 		DefaultBase:  "main",
-		Modules:     []Module{},
+		Modules:      []Module{},
 	}
 
 	err := SaveConfig(cfg, "/invalid/path/that/does/not/exist/test.yaml")

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/atotto/clipboard"
@@ -65,11 +67,40 @@ var (
 	ErrFeatureNotFound           = errors.New("未找到 feature")
 )
 
+var (
+	isAppInstalled = defaultIsAppInstalled
+	startCommand   = defaultStartCommand
+)
+
+func defaultIsAppInstalled(app string) bool {
+	if strings.TrimSpace(app) == "" || runtime.GOOS != "darwin" {
+		return false
+	}
+	return exec.Command("open", "-Ra", app).Run() == nil
+}
+
+func defaultStartCommand(name string, args ...string) error {
+	return exec.Command(name, args...).Start()
+}
+
 // ListEntry 列表项统一接口（主项目或 feature）
 type ListEntry interface {
 	IsMainProject() bool
 	GetName() string
 	GetDirtyCount() int
+}
+
+type operationMenuItem struct {
+	label    string
+	shortcut string
+	run      func() tea.Cmd
+}
+
+func (item operationMenuItem) display() string {
+	if item.shortcut == "" {
+		return item.label
+	}
+	return fmt.Sprintf("%s (%s)", item.label, item.shortcut)
 }
 
 // MainProjectEntry 主项目列表项
@@ -109,24 +140,34 @@ type App struct {
 	Envs         []core.WorktreeEnv
 	mainProject  *engine.MainProjectStatus
 	selected     int
-	menuSelected int    // 操作菜单选中项: 0=打开VSCode, 1=Modules管理, 2=删除
+	menuSelected int    // 操作菜单选中项
 	state        string // "loading", "list", "menu", "modules", "confirm", "error"
 	feature      string
 	err          error
 	message      string
+	// 配置化 App 打开工具
+	availableAppOpeners []config.AppOpener
+	appOpenersResolved  bool
 	// 模块管理相关字段
 	moduleSelector    *ModuleSelector // 模块选择器
 	moduleCursor      int             // 模块列表光标位置
 	modulesFeature    string          // 当前操作的 feature 名称
 	isMainProjectMenu bool            // 当前菜单是否为主项目菜单
+	// 创建 feature 相关字段
+	createFeatureInput  []rune // feature 名称输入内容
+	createFeatureCursor int    // feature 名称输入光标
+	createFeatureError  string // feature 名称输入校验提示
+	createFeature       string // 当前待创建的 feature 名称
 }
 
 // New 创建 TUI App
 func New(cfg *config.Config) *App {
-	return &App{
+	app := &App{
 		Engine: engine.New(cfg),
 		state:  "loading",
 	}
+	app.resolveAvailableAppOpeners()
+	return app
 }
 
 // Model 实现 tea.Model 接口
@@ -157,6 +198,11 @@ type updateDoneMsg struct {
 
 // refreshListMsg 请求重新加载列表（如模块变更后）
 type refreshListMsg struct{}
+
+type createFeatureDoneMsg struct {
+	feature string
+	err     error
+}
 
 type errorMsg struct {
 	err error
@@ -189,6 +235,16 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case refreshListMsg:
 		m.state = "loading"
 		return m, m.loadEnvs
+	case createFeatureDoneMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			m.state = "error"
+			return m, nil
+		}
+		m.message = "已创建 feature: " + msg.feature
+		m.resetCreateFeature()
+		m.state = "loading"
+		return m, m.loadEnvs
 	case errorMsg:
 		m.err = msg.err
 		m.state = "error"
@@ -200,6 +256,10 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleMenuKey(msg)
 		case "modules":
 			return m.handleModulesKey(msg)
+		case "create_input":
+			return m.handleCreateInputKey(msg)
+		case "create_modules":
+			return m.handleCreateModulesKey(msg)
 		case "confirm":
 			return m.handleConfirmKey(msg)
 		case "error":
@@ -290,6 +350,8 @@ func (m *App) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+	case "n":
+		m.startCreateFeature()
 	case "q", "esc":
 		return m, tea.Quit
 	}
@@ -333,6 +395,25 @@ func (m *App) getSelectedPath() (string, error) {
 	return env.MainProject.Path, nil
 }
 
+// getSelectedOpenPath 获取选中项的主项目路径，用于打开工具。
+func (m *App) getSelectedOpenPath() (string, error) {
+	entry := m.selectedListEntry()
+	if entry == nil {
+		return "", fmt.Errorf("未选中任何项目: %w", ErrNoSelection)
+	}
+	if entry.IsMainProject() {
+		if m.mainProject == nil {
+			return "", fmt.Errorf("主项目信息不存在: %w", ErrMainProjectNotFound)
+		}
+		return m.mainProject.Path, nil
+	}
+	env := m.selectedFeatureEnv()
+	if env == nil || env.MainProject == nil {
+		return "", fmt.Errorf("该 feature 无主项目，无法打开: %w", ErrFeatureCannotOpen)
+	}
+	return env.MainProject.Path, nil
+}
+
 // copyPathAndBack 复制路径并返回列表视图
 func (m *App) copyPathAndBack() {
 	path, err := m.getSelectedPath()
@@ -347,6 +428,150 @@ func (m *App) copyPathAndBack() {
 		return
 	}
 	m.message = "路径已复制: " + path
+	m.state = "list"
+}
+
+func (m *App) ensureAvailableAppOpeners() {
+	if !m.appOpenersResolved {
+		m.resolveAvailableAppOpeners()
+	}
+}
+
+func (m *App) resolveAvailableAppOpeners() {
+	m.availableAppOpeners = nil
+	if m.Engine == nil || m.Engine.Config == nil {
+		m.appOpenersResolved = true
+		return
+	}
+	for _, opener := range m.Engine.Config.AppOpeners {
+		if isAppInstalled(opener.App) {
+			m.availableAppOpeners = append(m.availableAppOpeners, opener)
+		}
+	}
+	m.appOpenersResolved = true
+}
+
+func (m *App) operationMenuItems() []operationMenuItem {
+	m.ensureAvailableAppOpeners()
+
+	items := []operationMenuItem{
+		{label: "打开 VS Code", shortcut: "o", run: m.openVSCodeSelected},
+		{label: "打开 Codex", shortcut: "x", run: func() tea.Cmd {
+			m.openAppByName("Codex")
+			return nil
+		}},
+	}
+
+	items = append(items, m.configuredAppOpenerMenuItems()...)
+	items = append(items, operationMenuItem{label: "复制路径", shortcut: "c", run: func() tea.Cmd {
+		m.copyPathAndBack()
+		return nil
+	}})
+
+	if m.isMainProjectMenu {
+		items = append(items, operationMenuItem{label: "更新代码", shortcut: "u", run: func() tea.Cmd {
+			m.state = "loading"
+			return m.executeUpdateCode()
+		}})
+		return items
+	}
+
+	items = append(items,
+		operationMenuItem{label: "更新代码", shortcut: "u", run: func() tea.Cmd {
+			if env := m.selectedFeatureEnv(); env != nil {
+				m.state = "loading"
+				return m.executeUpdateWorktree(env.Name)
+			}
+			return nil
+		}},
+		operationMenuItem{label: "Modules 管理", shortcut: "m", run: func() tea.Cmd {
+			m.initModuleSelector()
+			m.state = "modules"
+			return nil
+		}},
+		operationMenuItem{label: "删除", shortcut: "d", run: func() tea.Cmd {
+			if env := m.selectedFeatureEnv(); env != nil {
+				m.state = "confirm"
+				m.feature = env.Name
+			}
+			return nil
+		}},
+	)
+	return items
+}
+
+func (m *App) configuredAppOpenerMenuItems() []operationMenuItem {
+	reserved := builtinMenuShortcuts()
+	shortcutCounts := make(map[string]int)
+	for _, opener := range m.availableAppOpeners {
+		key := normalizeMenuShortcut(opener.Shortcut)
+		if key != "" {
+			shortcutCounts[key]++
+		}
+	}
+
+	items := make([]operationMenuItem, 0, len(m.availableAppOpeners))
+	for _, opener := range m.availableAppOpeners {
+		opener := opener
+		label := "打开 " + appOpenerLabel(opener)
+		shortcut := normalizeMenuShortcut(opener.Shortcut)
+		if shortcut != "" && (reserved[shortcut] || shortcutCounts[shortcut] > 1) {
+			shortcut = ""
+		}
+		items = append(items, operationMenuItem{label: label, shortcut: shortcut, run: func() tea.Cmd {
+			m.openAppByName(opener.App)
+			return nil
+		}})
+	}
+	return items
+}
+
+func builtinMenuShortcuts() map[string]bool {
+	return map[string]bool{
+		"o": true,
+		"x": true,
+		"c": true,
+		"u": true,
+		"m": true,
+		"d": true,
+		"q": true,
+	}
+}
+
+func normalizeMenuShortcut(shortcut string) string {
+	if shortcut == "" {
+		return ""
+	}
+	return strings.ToLower(shortcut)
+}
+
+func appOpenerLabel(opener config.AppOpener) string {
+	if strings.TrimSpace(opener.Label) != "" {
+		return strings.TrimSpace(opener.Label)
+	}
+	return strings.TrimSpace(opener.App)
+}
+
+func (m *App) openVSCodeSelected() tea.Cmd {
+	path, err := m.getSelectedOpenPath()
+	if err != nil {
+		m.err = err
+		m.state = "error"
+		return nil
+	}
+	_ = startCommand("code", path)
+	m.state = "list"
+	return nil
+}
+
+func (m *App) openAppByName(appName string) {
+	path, err := m.getSelectedOpenPath()
+	if err != nil {
+		m.err = err
+		m.state = "error"
+		return
+	}
+	_ = startCommand("open", "-a", appName, path)
 	m.state = "list"
 }
 
@@ -391,126 +616,35 @@ func (m *App) initModuleSelector() {
 }
 
 func (m *App) handleMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	menuLen := 4
-	if !m.isMainProjectMenu {
-		menuLen = 6
+	menuItems := m.operationMenuItems()
+	if len(menuItems) == 0 {
+		m.state = "list"
+		return m, nil
 	}
+	if m.menuSelected >= len(menuItems) {
+		m.menuSelected = len(menuItems) - 1
+	}
+
 	switch msg.String() {
 	case "up", "k":
 		if m.menuSelected > 0 {
 			m.menuSelected--
 		}
 	case "down", "j":
-		if m.menuSelected < menuLen-1 {
+		if m.menuSelected < len(menuItems)-1 {
 			m.menuSelected++
 		}
 	case "enter":
-		// 检查当前选中项是否绑定了 x 快捷键（显示为 "打开 Codex (x)"）
-		isCodexItem := false
-		if m.isMainProjectMenu && m.mainProject != nil && m.menuSelected == 1 {
-			isCodexItem = true
-		} else if !m.isMainProjectMenu && m.menuSelected == 1 {
-			isCodexItem = true
-		}
-		if isCodexItem {
-			path, err := m.getSelectedPath()
-			if err != nil {
-				m.err = err
-				m.state = "error"
-			} else {
-				cmd := exec.Command("open", "-a", "Codex", path)
-				_ = cmd.Start()
-				m.state = "list"
-			}
-		} else if m.isMainProjectMenu {
-			switch m.menuSelected {
-			case 0:
-				if m.mainProject != nil {
-					cmd := exec.Command("code", m.mainProject.Path)
-					_ = cmd.Start()
-					m.state = "list"
-				}
-			case 1:
-				m.copyPathAndBack()
-			case 2:
-				m.state = "loading"
-				return m, m.executeUpdateCode()
-			}
-		} else {
-			switch m.menuSelected {
-			case 0:
-				if env := m.selectedFeatureEnv(); env != nil && env.MainProject != nil {
-					cmd := exec.Command("code", env.MainProject.Path)
-					_ = cmd.Start()
-					m.state = "list"
-				} else {
-					m.err = fmt.Errorf("该 feature 无主项目，无法打开: %w", ErrFeatureCannotOpen)
-					m.state = "error"
-				}
-			case 1:
-				m.copyPathAndBack()
-			case 2:
-				if env := m.selectedFeatureEnv(); env != nil {
-					m.state = "loading"
-					return m, m.executeUpdateWorktree(env.Name)
-				}
-			case 3:
-				m.initModuleSelector()
-				m.state = "modules"
-			case 4:
-				if env := m.selectedFeatureEnv(); env != nil {
-					m.state = "confirm"
-					m.feature = env.Name
-				}
-			}
-		}
-	case "m":
-		if !m.isMainProjectMenu {
-			m.initModuleSelector()
-			m.state = "modules"
-		}
-	case "d":
-		if !m.isMainProjectMenu {
-			m.state = "confirm"
-			if env := m.selectedFeatureEnv(); env != nil {
-				m.feature = env.Name
-			}
-		}
-	case "o":
-		if m.isMainProjectMenu && m.mainProject != nil {
-			cmd := exec.Command("code", m.mainProject.Path)
-			_ = cmd.Start()
-			m.state = "list"
-		} else if env := m.selectedFeatureEnv(); env != nil && env.MainProject != nil {
-			cmd := exec.Command("code", env.MainProject.Path)
-			_ = cmd.Start()
-			m.state = "list"
-		} else if !m.isMainProjectMenu {
-			m.err = fmt.Errorf("该 feature 无主项目，无法打开: %w", ErrFeatureCannotOpen)
-			m.state = "error"
-		}
-	case "x":
-		path, err := m.getSelectedPath()
-		if err != nil {
-			m.err = err
-			m.state = "error"
-		} else {
-			cmd := exec.Command("open", "-a", "Codex", path)
-			_ = cmd.Start()
-			m.state = "list"
-		}
-	case "c":
-		m.copyPathAndBack()
-	case "u":
-		if m.isMainProjectMenu {
-			m.state = "loading"
-			return m, m.executeUpdateCode()
-		} else if env := m.selectedFeatureEnv(); env != nil {
-			m.state = "loading"
-			return m, m.executeUpdateWorktree(env.Name)
-		}
+		return m, menuItems[m.menuSelected].run()
 	case "q", "esc":
 		m.state = "list"
+	default:
+		key := normalizeMenuShortcut(msg.String())
+		for _, item := range menuItems {
+			if item.shortcut != "" && item.shortcut == key {
+				return m, item.run()
+			}
+		}
 	}
 	return m, nil
 }
@@ -540,6 +674,134 @@ func (m *App) handleModulesKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m *App) startCreateFeature() {
+	m.state = "create_input"
+	m.createFeatureInput = nil
+	m.createFeatureCursor = 0
+	m.createFeatureError = ""
+	m.createFeature = ""
+	m.moduleSelector = nil
+	m.moduleCursor = 0
+}
+
+func (m *App) resetCreateFeature() {
+	m.createFeatureInput = nil
+	m.createFeatureCursor = 0
+	m.createFeatureError = ""
+	m.createFeature = ""
+	m.moduleSelector = nil
+	m.moduleCursor = 0
+}
+
+func (m *App) cancelCreateFeature() {
+	m.resetCreateFeature()
+	m.state = "list"
+}
+
+func (m *App) handleCreateInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.clampCreateFeatureCursor()
+
+	switch msg.String() {
+	case "esc", "ctrl+c":
+		m.cancelCreateFeature()
+	case "enter":
+		feature := strings.TrimSpace(string(m.createFeatureInput))
+		if feature == "" {
+			m.createFeatureError = "feature 名称不能为空"
+			return m, nil
+		}
+		m.createFeature = feature
+		m.createFeatureError = ""
+		m.initCreateModuleSelector()
+		m.state = "create_modules"
+	case "left":
+		if m.createFeatureCursor > 0 {
+			m.createFeatureCursor--
+		}
+	case "right":
+		if m.createFeatureCursor < len(m.createFeatureInput) {
+			m.createFeatureCursor++
+		}
+	case "home":
+		m.createFeatureCursor = 0
+	case "end":
+		m.createFeatureCursor = len(m.createFeatureInput)
+	case "backspace", "ctrl+h":
+		if m.createFeatureCursor > 0 {
+			m.createFeatureInput = append(m.createFeatureInput[:m.createFeatureCursor-1], m.createFeatureInput[m.createFeatureCursor:]...)
+			m.createFeatureCursor--
+			m.createFeatureError = ""
+		}
+	case "delete":
+		if m.createFeatureCursor < len(m.createFeatureInput) {
+			m.createFeatureInput = append(m.createFeatureInput[:m.createFeatureCursor], m.createFeatureInput[m.createFeatureCursor+1:]...)
+			m.createFeatureError = ""
+		}
+	default:
+		if len(msg.Runes) > 0 {
+			input := make([]rune, 0, len(m.createFeatureInput)+len(msg.Runes))
+			input = append(input, m.createFeatureInput[:m.createFeatureCursor]...)
+			input = append(input, msg.Runes...)
+			input = append(input, m.createFeatureInput[m.createFeatureCursor:]...)
+			m.createFeatureInput = input
+			m.createFeatureCursor += len(msg.Runes)
+			m.createFeatureError = ""
+		}
+	}
+	return m, nil
+}
+
+func (m *App) clampCreateFeatureCursor() {
+	if m.createFeatureCursor < 0 {
+		m.createFeatureCursor = 0
+	}
+	if m.createFeatureCursor > len(m.createFeatureInput) {
+		m.createFeatureCursor = len(m.createFeatureInput)
+	}
+}
+
+func (m *App) initCreateModuleSelector() {
+	var modules []config.Module
+	var defaultSelected []string
+	remoteHasBranch := make(map[string]bool)
+
+	if m.Engine != nil && m.Engine.Config != nil {
+		modules = m.Engine.Config.Modules
+		defaultSelected = m.Engine.Config.DefaultSelectedModules
+		var err error
+		remoteHasBranch, err = m.Engine.GetModulesWithRemoteBranch(context.Background(), m.createFeature)
+		if err != nil {
+			remoteHasBranch = make(map[string]bool)
+		}
+	}
+
+	m.moduleSelector = NewModuleSelector(modules, nil, remoteHasBranch, defaultSelected, "选择要创建的项目/模块")
+	m.moduleCursor = 0
+}
+
+func (m *App) handleCreateModulesKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if m.moduleCursor > 0 {
+			m.moduleCursor--
+		}
+	case "down", "j":
+		if m.moduleSelector != nil && m.moduleCursor < len(m.moduleSelector.modules)-1 {
+			m.moduleCursor++
+		}
+	case " ":
+		if m.moduleSelector != nil && m.moduleCursor >= 0 && m.moduleCursor < len(m.moduleSelector.selected) {
+			m.moduleSelector.selected[m.moduleCursor] = !m.moduleSelector.selected[m.moduleCursor]
+		}
+	case "enter":
+		m.state = "loading"
+		return m, m.executeCreateFeature()
+	case "q", "esc", "ctrl+c":
+		m.cancelCreateFeature()
+	}
+	return m, nil
+}
+
 // executeUpdateCode 执行主项目+模块更新，返回在后台运行并发送 updateDoneMsg 的 Cmd
 func (m *App) executeUpdateCode() tea.Cmd {
 	return func() tea.Msg {
@@ -553,6 +815,28 @@ func (m *App) executeUpdateWorktree(feature string) tea.Cmd {
 	return func() tea.Msg {
 		success, failed := m.Engine.UpdateWorktree(context.Background(), feature)
 		return updateDoneMsg{success: success, failed: failed, feature: feature}
+	}
+}
+
+func (m *App) executeCreateFeature() tea.Cmd {
+	feature := m.createFeature
+	var selectedModules []config.Module
+	if m.moduleSelector != nil {
+		selectedModules = m.moduleSelector.SelectedModules()
+	}
+
+	return func() tea.Msg {
+		if m.Engine == nil || m.Engine.Config == nil || m.Engine.GitProxy == nil {
+			return createFeatureDoneMsg{feature: feature, err: errors.New("TUI 引擎未初始化")}
+		}
+
+		createCfg := *m.Engine.Config
+		createCfg.Modules = append([]config.Module(nil), selectedModules...)
+		createEngine := engine.NewWithClient(&createCfg, m.Engine.GitProxy)
+		if err := createEngine.CreateWorktree(context.Background(), feature, createCfg.DefaultBase); err != nil {
+			return createFeatureDoneMsg{feature: feature, err: err}
+		}
+		return createFeatureDoneMsg{feature: feature}
 	}
 }
 
@@ -628,6 +912,10 @@ func (m *App) View() string {
 		return m.renderMenu()
 	case "modules":
 		return m.renderModules()
+	case "create_input":
+		return m.renderCreateInput()
+	case "create_modules":
+		return m.renderCreateModules()
 	case "confirm":
 		return m.renderConfirm()
 	case "error":
@@ -666,7 +954,7 @@ func (m *App) renderList() string {
 	var s strings.Builder
 	s.WriteString(headerStyle.Render("modu - Worktree Manager"))
 	s.WriteString("\n\n")
-	s.WriteString(itemStyle.Render("↑/↓ 选择  Enter 回车  m 管理模块  u 更新代码  c 复制路径\nd 删除  o 打开 VS Code  x 打开 Codex  q/esc 退出"))
+	s.WriteString(itemStyle.Render("↑/↓ 选择  Enter 回车  n 新建 feature  m 管理模块  u 更新代码  c 复制路径\nd 删除  o 打开 VS Code  x 打开 Codex  q/esc 退出"))
 	s.WriteString("\n\n")
 
 	total := m.listEntryCount()
@@ -742,28 +1030,22 @@ func (m *App) renderMenu() string {
 
 	if m.isMainProjectMenu && m.mainProject != nil {
 		s.WriteString(fmt.Sprintf("当前选中: %s [主项目] (<dirty状态>)\n\n", m.mainProject.Name))
-		menuItems := []string{"打开 VS Code (o)", "打开 Codex (x)", "复制路径 (c)", "更新代码 (u)"}
-		for i, item := range menuItems {
-			if i == m.menuSelected {
-				s.WriteString(selectedItemStyle.Render(fmt.Sprintf("→ %s", item)))
-			} else {
-				s.WriteString(itemStyle.Render(fmt.Sprintf("  %s", item)))
-			}
-			s.WriteString("\n")
-		}
 	} else {
 		if env := m.selectedFeatureEnv(); env != nil {
 			s.WriteString(fmt.Sprintf("当前选中: %s\n\n", env.Name))
 		}
-		menuItems := []string{"打开 VS Code (o)", "打开 Codex (x)", "复制路径 (c)", "更新代码 (u)", "Modules 管理 (m)", "删除 (d)"}
-		for i, item := range menuItems {
-			if i == m.menuSelected {
-				s.WriteString(selectedItemStyle.Render(fmt.Sprintf("→ %s", item)))
-			} else {
-				s.WriteString(itemStyle.Render(fmt.Sprintf("  %s", item)))
-			}
-			s.WriteString("\n")
+	}
+	menuItems := m.operationMenuItems()
+	if m.menuSelected >= len(menuItems) && len(menuItems) > 0 {
+		m.menuSelected = len(menuItems) - 1
+	}
+	for i, item := range menuItems {
+		if i == m.menuSelected {
+			s.WriteString(selectedItemStyle.Render(fmt.Sprintf("→ %s", item.display())))
+		} else {
+			s.WriteString(itemStyle.Render(fmt.Sprintf("  %s", item.display())))
 		}
+		s.WriteString("\n")
 	}
 	s.WriteString("\n")
 	s.WriteString(itemStyle.Render("按 ↑/↓ 选择，Enter 执行，esc 返回"))
@@ -806,6 +1088,78 @@ func (m *App) renderModules() string {
 	s.WriteString("\n")
 	s.WriteString(itemStyle.Render("空格切换选择，Enter 确认，q/esc 返回"))
 	return s.String()
+}
+
+func (m *App) renderCreateInput() string {
+	var s strings.Builder
+	s.WriteString(headerStyle.Render("新建 feature"))
+	s.WriteString("\n\n")
+	s.WriteString("请输入 feature 名称:\n\n")
+	s.WriteString(selectedItemStyle.Render(m.renderCreateFeatureInputValue()))
+	s.WriteString("\n\n")
+	if m.createFeatureError != "" {
+		s.WriteString(errorStyle.Render(m.createFeatureError))
+		s.WriteString("\n\n")
+	}
+	s.WriteString(itemStyle.Render("Enter 继续，Esc/Ctrl+C 取消"))
+	return s.String()
+}
+
+func (m *App) renderCreateFeatureInputValue() string {
+	m.clampCreateFeatureCursor()
+	before := string(m.createFeatureInput[:m.createFeatureCursor])
+	after := string(m.createFeatureInput[m.createFeatureCursor:])
+	return before + "▌" + after
+}
+
+func (m *App) renderCreateModules() string {
+	var s strings.Builder
+	s.WriteString(headerStyle.Render("新建 feature"))
+	s.WriteString("\n\n")
+	s.WriteString(fmt.Sprintf("当前 feature: %s\n\n", m.createFeature))
+	s.WriteString(successStyle.Render(fmt.Sprintf("[x] 主项目: %s（始终创建）", m.createMainProjectName())))
+	s.WriteString("\n")
+
+	if m.moduleSelector == nil || len(m.moduleSelector.modules) == 0 {
+		s.WriteString(itemStyle.Render("未配置可选模块，将只创建主项目。"))
+		s.WriteString("\n\n")
+		s.WriteString(itemStyle.Render("Enter 创建，q/esc 取消"))
+		return s.String()
+	}
+
+	for i, module := range m.moduleSelector.modules {
+		cursor := " "
+		if m.moduleCursor == i {
+			cursor = ">"
+		}
+
+		checkbox := "[ ]"
+		if m.moduleSelector.selected[i] {
+			checkbox = "[x]"
+		}
+
+		line := fmt.Sprintf("%s %s %s", cursor, checkbox, module.Name)
+		if m.moduleCursor == i {
+			s.WriteString(selectedItemStyle.Render(line))
+		} else {
+			s.WriteString(itemStyle.Render(line))
+		}
+		s.WriteString("\n")
+	}
+
+	s.WriteString("\n")
+	s.WriteString(itemStyle.Render("空格切换模块，Enter 创建，q/esc 取消"))
+	return s.String()
+}
+
+func (m *App) createMainProjectName() string {
+	if m.mainProject != nil && m.mainProject.Name != "" {
+		return m.mainProject.Name
+	}
+	if m.Engine != nil && m.Engine.Config != nil && m.Engine.Config.Workspace != "" {
+		return filepath.Base(m.Engine.Config.Workspace)
+	}
+	return "主项目"
 }
 
 func (m *App) renderError() string {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,6 +1,9 @@
 package ui
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,6 +12,7 @@ import (
 	"github.com/qimaotech/modu/internal/config"
 	"github.com/qimaotech/modu/internal/core"
 	"github.com/qimaotech/modu/internal/engine"
+	"github.com/qimaotech/modu/internal/gitproxy"
 )
 
 // TestMainProjectEntry_IsMainProject 主项目列表项返回 true
@@ -429,7 +433,7 @@ func TestApp_getSelectedPath_Feature(t *testing.T) {
 	app := &App{
 		mainProject: &engine.MainProjectStatus{Name: "main"},
 		Envs: []core.WorktreeEnv{{
-			Name: "feat-a",
+			Name:        "feat-a",
 			MainProject: &core.ModuleStatus{Name: "main", Path: "/path/to/main"},
 		}},
 		selected: 1,
@@ -486,4 +490,551 @@ func TestApp_copyPathAndBack_ClipboardError(t *testing.T) {
 	if app.state != "error" && app.state != "list" {
 		t.Errorf("copyPathAndBack() 后 state 应为 error 或 list, got %q", app.state)
 	}
+}
+
+func TestApp_renderMenu_ConfiguredAppOpeners(t *testing.T) {
+	withAppOpenerHooks(t, map[string]bool{
+		"Zed":    true,
+		"Cursor": true,
+	})
+
+	app := New(&config.Config{
+		Workspace:    "/workspace/main",
+		WorktreeRoot: "/workspace/worktrees",
+		DefaultBase:  "develop",
+		AppOpeners: []config.AppOpener{
+			{Name: "zed", App: "Zed", Label: "Zed", Shortcut: "z"},
+			{Name: "ghost", App: "Ghost", Label: "Ghost", Shortcut: "g"},
+			{Name: "cursor", App: "Cursor", Label: "Cursor", Shortcut: "c"},
+		},
+	})
+	app.state = "menu"
+	app.mainProject = &engine.MainProjectStatus{Name: "main", Path: "/workspace/main"}
+	app.selected = 0
+	app.isMainProjectMenu = true
+
+	view := app.renderMenu()
+	if !strings.Contains(view, "打开 Zed (z)") {
+		t.Fatalf("menu should render installed Zed opener with shortcut, got:\n%s", view)
+	}
+	if strings.Contains(view, "打开 Ghost") {
+		t.Fatalf("menu should hide missing app opener, got:\n%s", view)
+	}
+	if !strings.Contains(view, "打开 Cursor") {
+		t.Fatalf("menu should keep conflict opener selectable, got:\n%s", view)
+	}
+	if strings.Contains(view, "打开 Cursor (c)") {
+		t.Fatalf("menu should hide conflicting shortcut, got:\n%s", view)
+	}
+
+	codexIndex := strings.Index(view, "打开 Codex")
+	zedIndex := strings.Index(view, "打开 Zed")
+	copyIndex := strings.Index(view, "复制路径")
+	if !(codexIndex >= 0 && zedIndex > codexIndex && copyIndex > zedIndex) {
+		t.Fatalf("custom openers should render after built-in openers and before copy, got:\n%s", view)
+	}
+}
+
+func TestApp_handleMenuKey_ConfiguredAppOpenerShortcutAndEnter(t *testing.T) {
+	calls := withAppOpenerHooks(t, map[string]bool{"Zed": true})
+	app := New(&config.Config{
+		Workspace:    "/workspace/main",
+		WorktreeRoot: "/workspace/worktrees",
+		DefaultBase:  "develop",
+		AppOpeners: []config.AppOpener{
+			{Name: "zed", App: "Zed", Label: "Zed", Shortcut: "z"},
+		},
+	})
+	app.state = "menu"
+	app.mainProject = &engine.MainProjectStatus{Name: "main", Path: "/workspace/main"}
+	app.selected = 0
+	app.isMainProjectMenu = true
+
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+	if cmd != nil {
+		t.Fatal("configured app opener shortcut should not return a tea command")
+	}
+	assertStartedCommand(t, *calls, 0, "open", "-a", "Zed", "/workspace/main")
+	if app.state != "list" {
+		t.Fatalf("after opening configured app state = %q, want list", app.state)
+	}
+
+	app.state = "menu"
+	app.menuSelected = 2
+	_, cmd = app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("configured app opener enter should not return a tea command")
+	}
+	assertStartedCommand(t, *calls, 1, "open", "-a", "Zed", "/workspace/main")
+	if app.state != "list" {
+		t.Fatalf("after entering configured app state = %q, want list", app.state)
+	}
+}
+
+func TestApp_handleMenuKey_ConfiguredShortcutConflictKeepsBuiltIn(t *testing.T) {
+	calls := withAppOpenerHooks(t, map[string]bool{"Cursor": true})
+	app := New(&config.Config{
+		Workspace:    "/workspace/main",
+		WorktreeRoot: "/workspace/worktrees",
+		DefaultBase:  "develop",
+		AppOpeners: []config.AppOpener{
+			{Name: "cursor", App: "Cursor", Label: "Cursor", Shortcut: "c"},
+		},
+	})
+	app.state = "menu"
+	app.mainProject = &engine.MainProjectStatus{Name: "main", Path: "/workspace/main"}
+	app.selected = 0
+	app.isMainProjectMenu = true
+
+	_, _ = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	if len(*calls) != 0 {
+		t.Fatalf("conflicting c shortcut should trigger built-in copy, not Cursor open, got %+v", *calls)
+	}
+}
+
+func TestApp_handleMenuKey_ConfiguredAppOpenerMissingPath(t *testing.T) {
+	calls := withAppOpenerHooks(t, map[string]bool{"Zed": true})
+	app := New(&config.Config{
+		Workspace:    "/workspace/main",
+		WorktreeRoot: "/workspace/worktrees",
+		DefaultBase:  "develop",
+		AppOpeners: []config.AppOpener{
+			{Name: "zed", App: "Zed", Label: "Zed", Shortcut: "z"},
+		},
+	})
+	app.state = "menu"
+	app.Envs = []core.WorktreeEnv{{Name: "feat-a"}}
+	app.selected = 0
+	app.isMainProjectMenu = false
+
+	_, _ = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+	if app.state != "error" {
+		t.Fatalf("missing main project path should move to error, got %q", app.state)
+	}
+	if app.err == nil || !strings.Contains(app.err.Error(), "无法打开") {
+		t.Fatalf("missing main project path should show open error, got %v", app.err)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("missing path should not start app, got %+v", *calls)
+	}
+}
+
+// TestApp_ListKey_StartCreateAndQuit 保持列表 q 退出，同时新增 n 创建入口
+func TestApp_ListKey_StartCreateAndQuit(t *testing.T) {
+	app := &App{state: "list"}
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	if cmd != nil {
+		t.Error("按 n 进入创建输入不应返回命令")
+	}
+	if app.state != "create_input" {
+		t.Fatalf("按 n 后 state = %q，期望 create_input", app.state)
+	}
+
+	app = &App{state: "list"}
+	_, cmd = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd == nil {
+		t.Error("列表视图按 q 应保持退出行为")
+	}
+}
+
+type uiStartedCommand struct {
+	name string
+	args []string
+}
+
+func withAppOpenerHooks(t *testing.T, installed map[string]bool) *[]uiStartedCommand {
+	t.Helper()
+
+	oldIsAppInstalled := isAppInstalled
+	oldStartCommand := startCommand
+	calls := []uiStartedCommand{}
+
+	isAppInstalled = func(app string) bool {
+		return installed[app]
+	}
+	startCommand = func(name string, args ...string) error {
+		calls = append(calls, uiStartedCommand{name: name, args: append([]string(nil), args...)})
+		return nil
+	}
+
+	t.Cleanup(func() {
+		isAppInstalled = oldIsAppInstalled
+		startCommand = oldStartCommand
+	})
+	return &calls
+}
+
+func assertStartedCommand(t *testing.T, calls []uiStartedCommand, index int, name string, args ...string) {
+	t.Helper()
+	if len(calls) <= index {
+		t.Fatalf("expected command call %d, got %d calls: %+v", index, len(calls), calls)
+	}
+	call := calls[index]
+	if call.name != name {
+		t.Fatalf("command name = %q, want %q", call.name, name)
+	}
+	if len(call.args) != len(args) {
+		t.Fatalf("command args = %v, want %v", call.args, args)
+	}
+	for i := range args {
+		if call.args[i] != args[i] {
+			t.Fatalf("command args = %v, want %v", call.args, args)
+		}
+	}
+}
+
+// TestApp_renderList_IncludesCreateShortcut 列表帮助展示创建快捷键
+func TestApp_renderList_IncludesCreateShortcut(t *testing.T) {
+	app := &App{state: "list"}
+	view := app.renderList()
+	if !strings.Contains(view, "n 新建 feature") {
+		t.Fatalf("renderList() 应包含创建快捷键，got:\n%s", view)
+	}
+}
+
+// TestApp_CreateInput_QIsText 输入状态下 q 是普通文本
+func TestApp_CreateInput_QIsText(t *testing.T) {
+	app := &App{state: "create_input"}
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd != nil {
+		t.Error("输入 q 不应退出或返回命令")
+	}
+	if app.state != "create_input" {
+		t.Fatalf("输入 q 后 state = %q，期望 create_input", app.state)
+	}
+	if got := string(app.createFeatureInput); got != "q" {
+		t.Fatalf("输入内容 = %q，期望 q", got)
+	}
+}
+
+// TestApp_CreateInput_CursorMovement 光标可左右和首尾移动
+func TestApp_CreateInput_CursorMovement(t *testing.T) {
+	app := &App{state: "create_input", createFeatureInput: []rune("abcd"), createFeatureCursor: 2}
+
+	app.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if app.createFeatureCursor != 1 {
+		t.Fatalf("left 后 cursor = %d，期望 1", app.createFeatureCursor)
+	}
+	app.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if app.createFeatureCursor != 2 {
+		t.Fatalf("right 后 cursor = %d，期望 2", app.createFeatureCursor)
+	}
+	app.Update(tea.KeyMsg{Type: tea.KeyHome})
+	if app.createFeatureCursor != 0 {
+		t.Fatalf("home 后 cursor = %d，期望 0", app.createFeatureCursor)
+	}
+	app.Update(tea.KeyMsg{Type: tea.KeyEnd})
+	if app.createFeatureCursor != 4 {
+		t.Fatalf("end 后 cursor = %d，期望 4", app.createFeatureCursor)
+	}
+}
+
+// TestApp_CreateInput_InsertAndDeleteAtCursor 支持光标位置插入和删除
+func TestApp_CreateInput_InsertAndDeleteAtCursor(t *testing.T) {
+	app := &App{state: "create_input", createFeatureInput: []rune("abcd"), createFeatureCursor: 2}
+
+	app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if got := string(app.createFeatureInput); got != "abqcd" {
+		t.Fatalf("插入后 input = %q，期望 abqcd", got)
+	}
+	if app.createFeatureCursor != 3 {
+		t.Fatalf("插入后 cursor = %d，期望 3", app.createFeatureCursor)
+	}
+
+	app.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if got := string(app.createFeatureInput); got != "abcd" {
+		t.Fatalf("backspace 后 input = %q，期望 abcd", got)
+	}
+	if app.createFeatureCursor != 2 {
+		t.Fatalf("backspace 后 cursor = %d，期望 2", app.createFeatureCursor)
+	}
+
+	app.Update(tea.KeyMsg{Type: tea.KeyDelete})
+	if got := string(app.createFeatureInput); got != "abd" {
+		t.Fatalf("delete 后 input = %q，期望 abd", got)
+	}
+	if app.createFeatureCursor != 2 {
+		t.Fatalf("delete 后 cursor = %d，期望 2", app.createFeatureCursor)
+	}
+}
+
+// TestApp_CreateInput_EmptyNameValidation 空名称停留在输入状态并提示
+func TestApp_CreateInput_EmptyNameValidation(t *testing.T) {
+	app := &App{state: "create_input", createFeatureInput: []rune("   "), createFeatureCursor: 3}
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("空名称不应返回命令")
+	}
+	if app.state != "create_input" {
+		t.Fatalf("空名称后 state = %q，期望 create_input", app.state)
+	}
+	if app.createFeatureError == "" {
+		t.Fatal("空名称应设置中文校验提示")
+	}
+}
+
+// TestApp_CreateInput_Cancel Esc/Ctrl+C 取消创建输入
+func TestApp_CreateInput_Cancel(t *testing.T) {
+	app := &App{state: "create_input", createFeatureInput: []rune("feat"), createFeatureCursor: 4}
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Error("Esc 取消不应返回命令")
+	}
+	if app.state != "list" {
+		t.Fatalf("Esc 后 state = %q，期望 list", app.state)
+	}
+
+	app = &App{state: "create_input", createFeatureInput: []rune("feat"), createFeatureCursor: 4}
+	app.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if app.state != "list" {
+		t.Fatalf("Ctrl+C 后 state = %q，期望 list", app.state)
+	}
+}
+
+// TestApp_CreateInput_ValidNameInitializesSelection 有效名称进入项目选择并应用默认/远程预选
+func TestApp_CreateInput_ValidNameInitializesSelection(t *testing.T) {
+	fake := &uiFakeGitClient{remoteBranches: map[string]bool{"git@example.com:m2.git|feat-a": true}}
+	app := &App{
+		Engine: engine.NewWithClient(&config.Config{
+			Workspace:              t.TempDir(),
+			WorktreeRoot:           t.TempDir(),
+			DefaultBase:            "develop",
+			DefaultSelectedModules: []string{"m1"},
+			Modules: []config.Module{
+				{Name: "m1", URL: "git@example.com:m1.git"},
+				{Name: "m2", URL: "git@example.com:m2.git"},
+				{Name: "m3", URL: "git@example.com:m3.git"},
+			},
+			Concurrency: 2,
+		}, fake),
+		state:               "create_input",
+		createFeatureInput:  []rune("feat-a"),
+		createFeatureCursor: len("feat-a"),
+	}
+
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("初始化选择不应返回命令")
+	}
+	if app.state != "create_modules" {
+		t.Fatalf("有效名称后 state = %q，期望 create_modules", app.state)
+	}
+	if app.createFeature != "feat-a" {
+		t.Fatalf("createFeature = %q，期望 feat-a", app.createFeature)
+	}
+	if app.moduleSelector == nil {
+		t.Fatal("moduleSelector 不应为空")
+	}
+	if !app.moduleSelector.selected[0] || !app.moduleSelector.selected[1] || app.moduleSelector.selected[2] {
+		t.Fatalf("期望 m1 默认选中、m2 远程选中、m3 未选中，got %v", app.moduleSelector.selected)
+	}
+}
+
+// TestApp_CreateModules_Cancel 项目选择取消不调用创建
+func TestApp_CreateModules_Cancel(t *testing.T) {
+	fake := &uiFakeGitClient{}
+	app := &App{
+		Engine:         engine.NewWithClient(&config.Config{Workspace: t.TempDir(), WorktreeRoot: t.TempDir()}, fake),
+		state:          "create_modules",
+		createFeature:  "feat-a",
+		moduleSelector: NewModuleSelector([]config.Module{{Name: "m1"}}, nil, nil, nil, ""),
+	}
+
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd != nil {
+		t.Error("取消选择不应返回命令")
+	}
+	if app.state != "list" {
+		t.Fatalf("取消后 state = %q，期望 list", app.state)
+	}
+	if len(fake.createWorktreeCalls) != 0 {
+		t.Fatalf("取消不应创建 worktree，got %v", fake.createWorktreeCalls)
+	}
+}
+
+// TestApp_CreateModules_ConfirmCreatesSelectedModules 确认后只创建选中的模块
+func TestApp_CreateModules_ConfirmCreatesSelectedModules(t *testing.T) {
+	app, fake := newCreateFeatureTestApp(t)
+	app.moduleSelector.selected = []bool{true, false}
+
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("确认选择应返回创建命令")
+	}
+	_ = cmd()
+
+	if len(fake.createWorktreeCalls) != 2 {
+		t.Fatalf("期望创建主项目和 m1 两个 worktree，got %d: %v", len(fake.createWorktreeCalls), fake.createWorktreeCalls)
+	}
+	if fake.createWorktreeCalls[0].branch != "feat-a" || fake.createWorktreeCalls[0].baseBranch != "develop" {
+		t.Fatalf("主项目创建参数不正确: %+v", fake.createWorktreeCalls[0])
+	}
+	if fake.createWorktreeCalls[1].repoPath != filepath.Join(app.Engine.Config.Workspace, "m1") {
+		t.Fatalf("期望只创建 m1，got %+v", fake.createWorktreeCalls[1])
+	}
+}
+
+// TestApp_CreateModules_ConfirmCreatesMainOnly 零模块选择时只创建主项目
+func TestApp_CreateModules_ConfirmCreatesMainOnly(t *testing.T) {
+	app, fake := newCreateFeatureTestApp(t)
+	app.moduleSelector.selected = []bool{false, false}
+
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("确认零模块选择应返回创建命令")
+	}
+	_ = cmd()
+
+	if len(fake.createWorktreeCalls) != 1 {
+		t.Fatalf("期望仅创建主项目 worktree，got %d: %v", len(fake.createWorktreeCalls), fake.createWorktreeCalls)
+	}
+}
+
+// TestApp_CreateFeatureDone_SuccessReloadsList 创建成功后展示消息并触发列表刷新
+func TestApp_CreateFeatureDone_SuccessReloadsList(t *testing.T) {
+	app := &App{
+		Engine:              engine.NewWithClient(&config.Config{Workspace: t.TempDir(), WorktreeRoot: t.TempDir()}, &uiFakeGitClient{}),
+		state:               "loading",
+		createFeature:       "feat-a",
+		createFeatureInput:  []rune("feat-a"),
+		createFeatureCursor: len("feat-a"),
+	}
+
+	_, cmd := app.Update(createFeatureDoneMsg{feature: "feat-a"})
+	if app.state != "loading" {
+		t.Fatalf("成功后 state = %q，期望 loading 以刷新列表", app.state)
+	}
+	if app.message != "已创建 feature: feat-a" {
+		t.Fatalf("成功消息 = %q", app.message)
+	}
+	if app.createFeature != "" || len(app.createFeatureInput) != 0 {
+		t.Fatalf("成功后应清理创建状态, feature=%q input=%q", app.createFeature, string(app.createFeatureInput))
+	}
+	if cmd == nil {
+		t.Fatal("成功后应返回刷新列表命令")
+	}
+}
+
+// TestApp_CreateFeatureDone_ErrorShowsError 创建失败后进入错误状态
+func TestApp_CreateFeatureDone_ErrorShowsError(t *testing.T) {
+	app := &App{state: "loading"}
+
+	_, cmd := app.Update(createFeatureDoneMsg{feature: "feat-a", err: os.ErrInvalid})
+	if cmd != nil {
+		t.Error("失败后不应返回刷新命令")
+	}
+	if app.state != "error" {
+		t.Fatalf("失败后 state = %q，期望 error", app.state)
+	}
+	if app.err == nil {
+		t.Fatal("失败后应保留错误")
+	}
+}
+
+func newCreateFeatureTestApp(t *testing.T) (*App, *uiFakeGitClient) {
+	t.Helper()
+
+	workspace := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "worktrees")
+	for _, name := range []string{"m1", "m2"} {
+		if err := os.MkdirAll(filepath.Join(workspace, name), 0755); err != nil {
+			t.Fatalf("创建测试模块目录失败: %v", err)
+		}
+	}
+
+	fake := &uiFakeGitClient{}
+	cfg := &config.Config{
+		Workspace:    workspace,
+		WorktreeRoot: worktreeRoot,
+		DefaultBase:  "develop",
+		Modules: []config.Module{
+			{Name: "m1", URL: "git@example.com:m1.git"},
+			{Name: "m2", URL: "git@example.com:m2.git"},
+		},
+		Concurrency: 2,
+	}
+	app := &App{
+		Engine:         engine.NewWithClient(cfg, fake),
+		state:          "create_modules",
+		createFeature:  "feat-a",
+		moduleSelector: NewModuleSelector(cfg.Modules, nil, nil, nil, ""),
+	}
+	return app, fake
+}
+
+type uiFakeCreateWorktreeCall struct {
+	repoPath     string
+	branch       string
+	baseBranch   string
+	worktreePath string
+}
+
+type uiFakeGitClient struct {
+	remoteBranches      map[string]bool
+	createWorktreeCalls []uiFakeCreateWorktreeCall
+}
+
+func (f *uiFakeGitClient) Clone(ctx context.Context, url, path string) error {
+	return nil
+}
+
+func (f *uiFakeGitClient) CreateWorktree(ctx context.Context, repoPath, branch, baseBranch, worktreePath string) error {
+	f.createWorktreeCalls = append(f.createWorktreeCalls, uiFakeCreateWorktreeCall{
+		repoPath:     repoPath,
+		branch:       branch,
+		baseBranch:   baseBranch,
+		worktreePath: worktreePath,
+	})
+	return os.MkdirAll(worktreePath, 0755)
+}
+
+func (f *uiFakeGitClient) GetStatus(ctx context.Context, path string) (gitproxy.Status, error) {
+	return gitproxy.Status{Branch: "feat-a"}, nil
+}
+
+func (f *uiFakeGitClient) RemoveWorktree(ctx context.Context, path string) error {
+	return nil
+}
+
+func (f *uiFakeGitClient) RemoveWorktreeAndBranch(ctx context.Context, repoPath, worktreePath, featureDirName string) error {
+	return nil
+}
+
+func (f *uiFakeGitClient) ListWorktrees(ctx context.Context, repoPath string) ([]gitproxy.WorktreeInfo, error) {
+	return nil, nil
+}
+
+func (f *uiFakeGitClient) Fetch(ctx context.Context, repoPath string) error {
+	return nil
+}
+
+func (f *uiFakeGitClient) Rebase(ctx context.Context, path string) error {
+	return nil
+}
+
+func (f *uiFakeGitClient) FetchAndSwitchBranch(ctx context.Context, repoPath, branch string) error {
+	return nil
+}
+
+func (f *uiFakeGitClient) BranchExists(ctx context.Context, repoPath, branch string) bool {
+	return false
+}
+
+func (f *uiFakeGitClient) CheckBranchWorktreeStatus(ctx context.Context, repoPath, branch string) (bool, error) {
+	return false, nil
+}
+
+func (f *uiFakeGitClient) CreateWorktreeFromExistingBranch(ctx context.Context, repoPath, branch, worktreePath string) error {
+	return os.MkdirAll(worktreePath, 0755)
+}
+
+func (f *uiFakeGitClient) RemoteBranchExists(ctx context.Context, repoURL, branch string) bool {
+	if f.remoteBranches == nil {
+		return false
+	}
+	return f.remoteBranches[repoURL+"|"+branch]
+}
+
+func (f *uiFakeGitClient) CreateWorktreeFromRemoteBranch(ctx context.Context, repoPath, branch, worktreePath string) error {
+	return os.MkdirAll(worktreePath, 0755)
 }

--- a/openspec/changes/archive/2026-05-12-support-configurable-app-openers/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-12-support-configurable-app-openers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/archive/2026-05-12-support-configurable-app-openers/design.md
+++ b/openspec/changes/archive/2026-05-12-support-configurable-app-openers/design.md
@@ -1,0 +1,69 @@
+## Context
+
+当前 TUI 操作菜单在 `internal/ui/ui.go` 中直接维护固定菜单项，并分别用硬编码分支处理 VS Code、Codex、复制路径、更新代码、Modules 管理和删除。配置加载由 `internal/config` 读取 `.modu.yaml`，目前没有描述额外打开工具的字段。
+
+用户希望通过配置扩展操作菜单中的打开工具，例如 Zed、Cursor。该配置需要在 TUI 启动时读取，并根据本机是否安装对应 app 决定是否展示；如果快捷键与已有菜单项或其他 app opener 冲突，则菜单项仍可通过上下选择和 Enter 执行，但不展示、不绑定冲突快捷键。
+
+用户描述中的 `.mudu.yaml` 按项目现状理解为现有默认配置文件 `.modu.yaml`，避免引入第二套配置入口。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 在 `.modu.yaml` 中支持可选的自定义 app opener 列表。
+- TUI 启动时解析并过滤已安装的 app opener。
+- 操作菜单展示已安装 app opener，按配置顺序放在内置打开项之后、复制/更新/管理/删除等非打开操作之前。
+- 唯一且未被内置菜单占用的快捷键可触发对应 app opener；冲突快捷键不展示也不绑定。
+- 保持未配置时的现有行为。
+
+**Non-Goals:**
+
+- 不支持用户在 TUI 内编辑 app opener 配置。
+- 不新增跨平台 GUI app 发现依赖；优先使用系统已有命令完成安装检测。
+- 不改变 worktree 路径选择规则，仍打开当前选中条目的主项目路径。
+- 不把未安装 app 作为错误展示给用户。
+
+## Decisions
+
+1. **配置字段使用 `app-openers`**
+
+   增加 `Config.AppOpeners []AppOpener`，YAML 字段为 `app-openers`。每项包含稳定名称 `name`、系统 app 名称 `app`、可选展示名 `label`、可选快捷键 `shortcut`。
+
+   示例：
+
+   ```yaml
+   app-openers:
+     - name: zed
+       app: Zed
+       label: Zed
+       shortcut: z
+     - name: cursor
+       app: Cursor
+       label: Cursor
+       shortcut: c
+   ```
+
+   `label` 只表示 UI 中 "打开 <label>" 的显示文本；为空时使用 `app`。`shortcut` 为空时该项仅支持菜单选择后 Enter 执行。
+
+2. **配置校验只验证结构，不验证安装状态**
+
+   `name` 与 `app` 必填；`shortcut` 如存在必须是单个可打印字符。是否安装属于运行环境状态，由 TUI 启动时判断，避免同一配置在不同机器上因为安装状态不同而无法加载。
+
+3. **安装检测放在 TUI 层**
+
+   TUI 初始化时从 `m.Engine.Config.AppOpeners` 构建运行时菜单项。macOS 使用 `open -Ra <app>` 检测 app 是否可解析；其他平台可先返回不可用或后续补充平台实现。检测失败不进入错误状态，只是不展示该 opener。
+
+4. **菜单项统一建模**
+
+   用内部 `menuItem` 结构描述 label、shortcut、action、enabled path 需求等信息，渲染和执行都基于同一个菜单数组。这样可以消除当前 render 与 enter/key 分支各自维护顺序造成的偏移风险，也方便插入配置化 opener。
+
+5. **快捷键冲突在运行时降级**
+
+   TUI 先保留内置快捷键集合（例如 `o/x/c/u/m/d/q/esc`），再统计可见 app opener 的配置快捷键。快捷键与内置键冲突，或同一个键被多个可见 opener 使用时，对应 opener 渲染为 "打开 <label>"，不显示 `(key)`，也不响应该 key；用户仍可选中后按 Enter 打开。
+
+## Risks / Trade-offs
+
+- [Risk] macOS `open -Ra` 对 app 名称大小写或别名解析依赖系统行为 → Mitigation: 文档说明 `app` 应填写 `open -a` 可识别的应用名称，并用单元测试覆盖命令构造与失败隐藏逻辑。
+- [Risk] 继续在多个分支维护菜单顺序容易产生索引错位 → Mitigation: 重构为单一菜单构建函数，渲染、上下导航、Enter 执行和快捷键处理共享同一菜单数组。
+- [Risk] 用户为 Cursor 配置 `c` 时会与复制路径冲突 → Mitigation: 不报错、不绑定 `c`，菜单仍显示 "打开 Cursor"，用户可以 Enter 执行。
+- [Risk] 非 macOS 平台暂时无法可靠检测 GUI app → Mitigation: 将检测逻辑包在可替换函数中；当前实现无新增依赖，后续可补充平台实现。

--- a/openspec/changes/archive/2026-05-12-support-configurable-app-openers/proposal.md
+++ b/openspec/changes/archive/2026-05-12-support-configurable-app-openers/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+TUI 操作菜单目前把可打开的工具写死为 VS Code 和 Codex，用户无法按项目配置扩展到 Zed、Cursor 等常用编辑器。将打开工具改为配置驱动，可以让团队按自己的开发工具偏好扩展菜单，同时避免未安装工具或冲突快捷键破坏交互。
+
+## What Changes
+
+- 在现有 `.modu.yaml` 中增加可选的自定义 app opener 配置，描述展示名称、macOS app 名称、可选快捷键等信息。
+- TUI 启动时读取配置中的 app opener 列表，并检测对应 app 是否已安装。
+- 操作菜单只展示已安装的自定义 app opener，未安装的工具不展示。
+- 当自定义 app opener 的快捷键与内置菜单项或其他可见 opener 冲突时，菜单仍展示该 opener，但不展示也不绑定冲突快捷键。
+- 内置打开能力保持可用，支持以 Zed / `z` 作为配置示例。
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `config`: 配置文件结构新增可选 app opener 字段，并定义加载、校验与兼容规则。
+- `tui`: 操作菜单根据配置、安装检测和快捷键冲突结果动态展示打开工具项。
+
+## Impact
+
+- `internal/config`: 配置结构体、YAML 解析、校验与测试。
+- `internal/ui`: 操作菜单构建、渲染、快捷键处理、打开 app 命令与测试。
+- `README.md`: 配置示例和 TUI 快捷键说明需要补充。
+- 无新增依赖；安装检测优先使用系统已有能力。

--- a/openspec/changes/archive/2026-05-12-support-configurable-app-openers/specs/config/spec.md
+++ b/openspec/changes/archive/2026-05-12-support-configurable-app-openers/specs/config/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Configurable app openers
+
+配置文件 SHALL support an optional `app-openers` list for declaring extra GUI applications that can open the currently selected project path from the TUI operation menu.
+
+#### Scenario: Load Zed opener example
+- **WHEN** `.modu.yaml` contains an `app-openers` entry with `name: zed`, `app: Zed`, `label: Zed`, and `shortcut: z`
+- **THEN** config loading succeeds and exposes an app opener whose display text can be rendered as "打开 Zed" with shortcut `z`
+
+#### Scenario: Missing app openers remains compatible
+- **WHEN** `.modu.yaml` does not contain `app-openers`
+- **THEN** config loading succeeds and the TUI uses only built-in operation menu items
+
+#### Scenario: App opener without shortcut
+- **WHEN** an `app-openers` entry omits `shortcut`
+- **THEN** config loading succeeds and the opener is available for menu selection without a direct shortcut key
+
+### Requirement: App opener config validation
+
+Each configured app opener MUST include enough information to identify the app and MUST use a valid shortcut shape when a shortcut is provided.
+
+#### Scenario: Missing opener name is invalid
+- **WHEN** an `app-openers` entry has an empty `name`
+- **THEN** config loading fails with `ERR_CONFIG_INVALID`
+
+#### Scenario: Missing app name is invalid
+- **WHEN** an `app-openers` entry has an empty `app`
+- **THEN** config loading fails with `ERR_CONFIG_INVALID`
+
+#### Scenario: Shortcut must be a single printable key
+- **WHEN** an `app-openers` entry sets `shortcut` to more than one character or to a non-printable key
+- **THEN** config loading fails with `ERR_CONFIG_INVALID`
+
+#### Scenario: Shortcut conflict does not invalidate config
+- **WHEN** an `app-openers` entry sets `shortcut: c` and `c` is already used by a built-in TUI menu action
+- **THEN** config loading still succeeds because shortcut conflict resolution is handled by the TUI menu

--- a/openspec/changes/archive/2026-05-12-support-configurable-app-openers/specs/tui/spec.md
+++ b/openspec/changes/archive/2026-05-12-support-configurable-app-openers/specs/tui/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: 操作菜单显示
+用户按 Enter 后，TUI SHALL 显示操作菜单，包含内置操作选项，以及当前机器已安装的配置化 app opener。
+
+#### Scenario: 进入操作菜单
+- **WHEN** 用户在列表视图按 Enter
+- **THEN** TUI 显示操作菜单，当前选中第一项（打开 VS Code）
+
+#### Scenario: feature 操作菜单显示内置选项
+- **WHEN** 用户选中 feature 并进入操作菜单
+- **THEN** 菜单显示内置选项 "打开 VS Code"、"打开 Codex"、"复制路径"、"更新代码"、"Modules 管理" 和 "删除"
+
+#### Scenario: 已安装配置化 app opener 显示在菜单中
+- **WHEN** `.modu.yaml` 配置了 `app: Zed`、`label: Zed`、`shortcut: z` 的 app opener 且当前机器已安装 Zed
+- **THEN** 操作菜单显示 "打开 Zed (z)"，位置在内置打开项之后、非打开操作之前
+
+#### Scenario: 未安装配置化 app opener 不显示
+- **WHEN** `.modu.yaml` 配置了 `app: Cursor` 的 app opener 但当前机器未安装 Cursor
+- **THEN** 操作菜单不显示 "打开 Cursor"
+
+#### Scenario: 冲突快捷键不显示
+- **WHEN** `.modu.yaml` 配置了 `app: Cursor`、`label: Cursor`、`shortcut: c` 且 Cursor 已安装
+- **THEN** 操作菜单显示 "打开 Cursor" 且不显示 "(c)"，因为 `c` 已被复制路径占用
+
+### Requirement: 操作菜单执行操作
+用户 MUST 可以选择操作并执行；配置化 app opener 在可见时 MUST 支持 Enter 执行，并且仅在快捷键未冲突时支持直接按键执行。
+
+#### Scenario: Enter 执行选中操作
+- **WHEN** 用户在操作菜单按 Enter
+- **THEN** TUI 执行当前选中的操作
+
+#### Scenario: 执行删除操作
+- **WHEN** 用户在操作菜单选中"删除"项并按 d
+- **THEN** TUI 进入删除确认状态
+
+#### Scenario: 执行打开 VS Code
+- **WHEN** 用户在操作菜单选中"打开 VS Code"项并按 o
+- **THEN** 在 VS Code 中打开主项目，然后返回列表视图
+
+#### Scenario: Enter 执行配置化 app opener
+- **WHEN** 用户在操作菜单选中 "打开 Zed (z)" 并按 Enter
+- **THEN** TUI 使用配置的 app 名称打开当前选中条目的主项目路径，然后返回列表视图
+
+#### Scenario: 唯一快捷键执行配置化 app opener
+- **WHEN** 用户在操作菜单按下配置化 app opener 的唯一快捷键 `z`
+- **THEN** TUI 使用该 opener 的 app 名称打开当前选中条目的主项目路径，然后返回列表视图
+
+#### Scenario: 冲突快捷键不执行配置化 app opener
+- **WHEN** Cursor opener 配置了冲突快捷键 `c` 且用户在操作菜单按 `c`
+- **THEN** TUI 执行内置复制路径操作，而不是打开 Cursor
+
+#### Scenario: 配置化 app opener 缺少可打开路径
+- **WHEN** 用户对没有主项目路径的 feature 执行配置化 app opener
+- **THEN** TUI 进入错误状态并显示无法打开的中文错误信息
+
+#### Scenario: 退出操作菜单
+- **WHEN** 用户在操作菜单按 esc 或 q
+- **THEN** TUI 返回列表视图
+
+## ADDED Requirements
+
+### Requirement: App opener availability detection
+
+TUI SHALL determine configured app opener visibility at startup by checking whether each configured app can be resolved on the current machine.
+
+#### Scenario: Installed app is available
+- **WHEN** a configured app opener refers to an installed app
+- **THEN** TUI includes that opener in the operation menu
+
+#### Scenario: Missing app is unavailable
+- **WHEN** a configured app opener refers to an app that is not installed or cannot be resolved
+- **THEN** TUI excludes that opener from the operation menu without entering the error state
+
+#### Scenario: Availability is evaluated before rendering menu
+- **WHEN** the TUI first enters the list view after startup
+- **THEN** the operation menu model already contains only available configured app openers

--- a/openspec/changes/archive/2026-05-12-support-configurable-app-openers/tasks.md
+++ b/openspec/changes/archive/2026-05-12-support-configurable-app-openers/tasks.md
@@ -1,0 +1,25 @@
+## 1. Config Schema
+
+- [x] 1.1 Add `AppOpener` config model and `Config.AppOpeners` YAML field mapped to `app-openers`.
+- [x] 1.2 Validate configured openers: `name` and `app` are required, optional `shortcut` is a single printable key, and shortcut conflicts remain valid for TUI resolution.
+- [x] 1.3 Add config unit tests for the Zed example, missing `app-openers`, shortcut omission, missing required fields, invalid shortcut shape, and a built-in shortcut conflict.
+
+## 2. TUI Menu Model
+
+- [x] 2.1 Introduce a shared operation-menu item model used by rendering, cursor bounds, Enter execution, and direct shortcut execution.
+- [x] 2.2 Build menu items from built-in actions plus installed configured app openers, preserving config order and inserting custom openers after built-in open actions.
+- [x] 2.3 Add app availability detection for configured openers, using `open -Ra <app>` on macOS and hiding unavailable openers without surfacing an error.
+- [x] 2.4 Resolve shortcut conflicts against built-in operation-menu keys and other visible configured openers; conflicting openers remain selectable but render without a shortcut and do not bind that key.
+- [x] 2.5 Implement configured app opener execution with the current selected main project path and the configured app name.
+
+## 3. Documentation
+
+- [x] 3.1 Update README configuration documentation with an `app-openers` example using Zed and shortcut `z`.
+- [x] 3.2 Update TUI operation-menu shortcut documentation to describe configured app openers and conflict behavior.
+
+## 4. Verification
+
+- [x] 4.1 Add TUI tests for installed Zed rendering as "打开 Zed (z)", missing app hiding, Cursor `c` conflict rendering without `(c)`, unique shortcut execution, Enter execution, and missing-path error handling.
+- [x] 4.2 Run `gofmt` on changed Go files.
+- [x] 4.3 Run focused config and UI tests.
+- [x] 4.4 Run the project lint/test/build checks required before completion where practical.

--- a/openspec/changes/archive/2026-05-12-support-tui-feature-creation/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-12-support-tui-feature-creation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/archive/2026-05-12-support-tui-feature-creation/design.md
+++ b/openspec/changes/archive/2026-05-12-support-tui-feature-creation/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The current TUI (`internal/ui`) is a Bubble Tea state machine with list, menu, modules, confirm, loading, and error states. CLI feature creation already supports interactive module selection through `ui.SelectModules`, remote-branch preselection through `Engine.GetModulesWithRemoteBranch`, and worktree creation through `Engine.CreateWorktree`.
+
+The missing path is creating a feature from inside the TUI. The TUI also needs an editable feature-name input that behaves like a text field instead of treating every `q` keypress as a quit signal.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a list-view action to start TUI feature creation without disrupting existing shortcuts.
+- Add a dedicated feature-name input state with cursor movement and in-place editing.
+- Add a project/module selection state before creation, with the main project always included and configured modules selectable.
+- Reuse existing engine creation behavior, module defaults, and remote branch preselection where practical.
+- Keep all user-visible TUI text in Chinese.
+
+**Non-Goals:**
+
+- Changing CLI `modu create` behavior.
+- Adding new dependencies or replacing Bubble Tea primitives.
+- Changing the worktree directory naming rules or branch creation semantics.
+- Implementing multi-main-project configuration; the current workspace main project remains implicit and always included.
+
+## Decisions
+
+1. Use a dedicated TUI create state instead of overloading menu state.
+
+   The list view will expose a new `n` shortcut for "新建 feature". Existing `c` is already used for copy path, so reusing it would create a shortcut conflict. A separate state keeps key handling explicit: list-level `q` still quits, while create-input `q` inserts text.
+
+   Rejected alternative: add "创建 feature" to each selected-item operation menu. Creation is a global action rather than an operation on the selected worktree, so putting it in the per-item menu would blur menu semantics.
+
+2. Implement feature-name editing as a small local text input model.
+
+   Store the input as runes plus a cursor index, and handle printable runes, backspace, delete, left/right, home/end, Enter, Esc, and Ctrl+C. This avoids a dependency change and is enough for the requested cursor movement and edit behavior.
+
+   Rejected alternative: add a new text input dependency. The project already uses Bubble Tea directly, and the required behavior is narrow.
+
+3. Reuse `ModuleSelector` semantics for project/module selection.
+
+   After the user confirms a feature name, the TUI should query remote branch presence for configured modules, preselect configured defaults and modules that already have the remote branch, then allow selecting modules before creation. The main project is not optional; it is created as the feature root by `Engine.CreateWorktree`.
+
+   Rejected alternative: immediately create all modules after name input. That would not satisfy the requested project selection flow and would bypass existing default-selection behavior.
+
+4. Execute creation through the existing engine path.
+
+   The TUI should create a shallow copy of the loaded config with `Modules` narrowed to the selected modules, then call `CreateWorktree(ctx, featureName, DefaultBase)`. On success it reloads the list and shows a success message; on failure it enters the existing error state.
+
+   Rejected alternative: duplicate CLI `runCreate` logic in the UI. Reusing engine methods keeps branch/worktree handling in one place.
+
+## Risks / Trade-offs
+
+- [Risk] Feature names containing `/` are branches but map to `-` directories, while the list currently displays directory names. → Preserve existing engine naming behavior and avoid changing list display semantics in this change.
+- [Risk] Remote branch preselection may be slow or fail. → Follow CLI behavior: warn/degrade to an empty preselection map and still allow manual selection.
+- [Risk] `ModuleSelector` currently treats `q` as quit. → Keep that behavior for selection screens; only the feature-name input state treats `q` as typed text.
+- [Risk] Empty feature names can trigger confusing engine errors. → Validate and keep the user in the input state with a Chinese error before starting selection or creation.
+
+## Migration Plan
+
+No data migration is required. Existing CLI and TUI workflows remain valid. Rollback is a code revert of the TUI state additions and documentation/test updates.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-12-support-tui-feature-creation/proposal.md
+++ b/openspec/changes/archive/2026-05-12-support-tui-feature-creation/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Users can create features from the CLI, but the TUI currently focuses on listing and managing existing worktrees. Adding feature creation to the TUI closes that workflow gap and lets users stay in the interactive interface for the common create-and-select-modules path.
+
+## What Changes
+
+- Add a TUI entry point for creating a new feature from the list view.
+- Add a TUI project/module selection step for the feature being created, reusing configured modules and existing selection semantics.
+- Add a feature-name input state that supports cursor movement and in-place edits.
+- Ensure `q` does not exit while the user is typing the feature name; quit/cancel behavior remains available outside the input state.
+- Refresh the list and show a Chinese success or error message after creation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `tui`: TUI feature creation, project/module selection, editable feature-name input, and input-state key handling requirements change.
+
+## Impact
+
+- `internal/ui`: Bubble Tea state machine, rendering, key handling, module/project selection flow, and unit tests.
+- `internal/engine`: Existing `CreateWorktree`, remote-branch preselection, and configured module filtering may be reused by the TUI flow.
+- `README.md`: TUI shortcut documentation may need to mention the create action.

--- a/openspec/changes/archive/2026-05-12-support-tui-feature-creation/specs/tui/spec.md
+++ b/openspec/changes/archive/2026-05-12-support-tui-feature-creation/specs/tui/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: TUI feature creation entry
+The TUI SHALL provide a list-view action for starting feature creation without changing existing list navigation, open, update, copy, module-management, delete, or quit shortcuts.
+
+#### Scenario: Start creation from list view
+- **WHEN** the user is in the list view and presses `n`
+- **THEN** the TUI enters the feature-name input state for creating a new feature
+
+#### Scenario: Existing quit shortcut remains in list view
+- **WHEN** the user is in the list view and presses `q`
+- **THEN** the TUI exits as before
+
+#### Scenario: Create shortcut is shown
+- **WHEN** the TUI renders the list view
+- **THEN** the shortcut help includes the Chinese create-feature action
+
+### Requirement: Editable feature-name input
+The TUI SHALL let users enter and edit the feature name with cursor movement before selecting projects/modules.
+
+#### Scenario: Printable character insertion
+- **WHEN** the user types printable characters in the feature-name input state
+- **THEN** the characters are inserted at the current cursor position and the cursor moves after the inserted text
+
+#### Scenario: Cursor movement
+- **WHEN** the user presses left, right, home, or end in the feature-name input state
+- **THEN** the input cursor moves within the feature-name text without leaving the input state
+
+#### Scenario: In-place deletion
+- **WHEN** the user presses backspace or delete in the feature-name input state
+- **THEN** the TUI removes text adjacent to the cursor without leaving the input state
+
+#### Scenario: q is normal input text
+- **WHEN** the user presses `q` in the feature-name input state
+- **THEN** the TUI inserts `q` into the feature name and MUST NOT quit or cancel input
+
+#### Scenario: Empty name is rejected
+- **WHEN** the user presses Enter while the feature-name input is empty or whitespace-only
+- **THEN** the TUI remains in the feature-name input state and shows a Chinese validation message
+
+#### Scenario: Cancel feature-name input
+- **WHEN** the user presses Esc or Ctrl+C in the feature-name input state
+- **THEN** the TUI cancels creation and returns to the list view without creating a worktree
+
+### Requirement: Project selection before creation
+The TUI SHALL provide a project/module selection step after the user confirms a feature name and before any worktree creation starts.
+
+#### Scenario: Open selection after valid name
+- **WHEN** the user enters a non-empty feature name and presses Enter
+- **THEN** the TUI displays a selection view for configured projects/modules before creating the feature
+
+#### Scenario: Main project is included
+- **WHEN** the user reaches the project/module selection step
+- **THEN** the main project is treated as always included for feature creation
+
+#### Scenario: Configured modules are selectable
+- **WHEN** the project/module selection step is displayed
+- **THEN** each configured module is shown as selectable and can be toggled before confirmation
+
+#### Scenario: Default and remote branch preselection
+- **WHEN** configured default-selected modules or modules with the target remote branch exist
+- **THEN** those modules are preselected in the project/module selection step
+
+#### Scenario: Selection cancellation
+- **WHEN** the user cancels the project/module selection step
+- **THEN** the TUI returns to the list view without creating a worktree
+
+### Requirement: Create feature from TUI selection
+The TUI SHALL create the feature worktree after the user confirms project/module selection.
+
+#### Scenario: Create selected projects
+- **WHEN** the user confirms project/module selection for a feature name
+- **THEN** the TUI creates the main project worktree and only the selected module worktrees
+
+#### Scenario: Create with no selected modules
+- **WHEN** the user confirms creation with no modules selected
+- **THEN** the TUI creates the main project feature worktree without module worktrees
+
+#### Scenario: Creation success feedback
+- **WHEN** feature creation succeeds
+- **THEN** the TUI reloads the list view and shows a Chinese success message containing the feature name
+
+#### Scenario: Creation failure feedback
+- **WHEN** feature creation fails
+- **THEN** the TUI enters the error state and shows the creation error

--- a/openspec/changes/archive/2026-05-12-support-tui-feature-creation/tasks.md
+++ b/openspec/changes/archive/2026-05-12-support-tui-feature-creation/tasks.md
@@ -1,0 +1,31 @@
+## 1. TUI State And Entry
+
+- [x] 1.1 Add App fields for feature creation input text, cursor position, validation message, and create-specific module/project selection state.
+- [x] 1.2 Add a list-view `n` shortcut that enters the feature-name input state without changing existing list shortcuts.
+- [x] 1.3 Update list-view help text to include the Chinese create-feature action.
+
+## 2. Feature Name Input
+
+- [x] 2.1 Render a Chinese feature-name input view with visible current text, cursor position, validation feedback, and cancel/confirm hints.
+- [x] 2.2 Handle printable rune insertion at the cursor, including `q` as ordinary input text.
+- [x] 2.3 Handle left, right, home, end, backspace, and delete without leaving the input state.
+- [x] 2.4 Keep Enter on empty or whitespace-only input in the input state with a Chinese validation message.
+- [x] 2.5 Handle Esc and Ctrl+C as cancellation that returns to the list view without creating anything.
+
+## 3. Project Selection And Creation
+
+- [x] 3.1 After a valid feature name, query remote branch presence for configured modules and initialize selection with default-selected and remote-branch modules preselected.
+- [x] 3.2 Render the project/module selection step with the main project shown as always included and configured modules toggleable.
+- [x] 3.3 Handle selection cancellation by returning to the list view without calling the engine.
+- [x] 3.4 On selection confirmation, call `CreateWorktree` with the selected modules and the configured default base; allow zero selected modules to create only the main project worktree.
+- [x] 3.5 On creation success, reload the list view and show a Chinese success message containing the feature name.
+- [x] 3.6 On creation failure, enter the existing error state with the creation error.
+
+## 4. Tests And Documentation
+
+- [x] 4.1 Add unit tests for list `n` entry and list `q` quit behavior.
+- [x] 4.2 Add unit tests for feature-name input insertion, cursor movement, deletion, empty-name validation, `q` as input, and cancellation.
+- [x] 4.3 Add unit tests for project/module selection initialization and cancellation behavior.
+- [x] 4.4 Add unit tests or a focused fake-engine seam for selected-module creation behavior, including zero-module creation.
+- [x] 4.5 Update README TUI shortcut documentation for the create action.
+- [x] 4.6 Run `gofmt` on touched Go files and `go test ./...`.

--- a/openspec/specs/config/spec.md
+++ b/openspec/specs/config/spec.md
@@ -2,9 +2,9 @@
 
 **版本**: 2.4 | **来源**: docs/plans/2026-03-06-modu-design-v2.4.md
 
-## 目的
+## Purpose
 
-定义 modu 配置文件结构、加载与校验规则，以及 config 相关命令行为。
+定义 modu 配置文件结构、加载与校验规则，以及 config 相关命令行为。本规范约束 CLI 和 TUI 共享的配置字段、兼容性要求、路径解析方式和用户可扩展入口。
 
 ## 配置结构
 
@@ -18,6 +18,7 @@
 | `concurrency` | int | 否 | 并发数，默认 5 |
 | `auto-fetch` | bool | 否 | 操作前自动 fetch |
 | `strict-dirty-check` | bool | 否 | 删除前强制脏检查 |
+| `app-openers` | []AppOpener | 否 | TUI 操作菜单中额外可用的 GUI 应用打开器 |
 | `modules` | []Module | 是 | 模块列表，至少一个 |
 
 ### Module
@@ -28,12 +29,22 @@
 | `url` | string | 是 | 仓库 URL |
 | `base-branch` | string | 否 | 覆盖全局 default-base |
 
+### AppOpener
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | 是 | 配置项标识 |
+| `app` | string | 是 | macOS `open -a` 使用的应用名称 |
+| `label` | string | 否 | 操作菜单展示名称；为空时使用 `app` |
+| `shortcut` | string | 否 | 操作菜单直接执行快捷键，必须是单个可打印字符 |
+
 ## 加载与校验
 
 - 支持通过 `-c`/`--config` 指定配置文件路径，默认 `.modu.yaml`。
 - **必填校验**：缺失 `workspace`、`worktree-root`、`default-base` 或 `modules` 为空时，返回 `ERR_CONFIG_INVALID`。
 - **路径**：`workspace`、`worktree-root` 若为相对路径，则相对于配置文件所在目录解析为绝对路径。
 - **环境变量**：`workspace`、`worktree-root` 支持 `$VAR` 和 `${VAR}` 语法，环境变量必须已定义，否则加载失败并报错。详见 [config-env-var](../config-env-var/spec.md)。
+- **App opener 校验**：`app-openers` 为可选字段；每个条目必须提供 `name` 和 `app`，`shortcut` 若存在则必须是单个可打印字符。快捷键冲突不使配置加载失败，由 TUI 操作菜单在展示与绑定时处理。
 - **LoadConfigForScan**：scan 场景可仅校验基础字段，不强制校验 modules（用于先扫后写配置）。
 
 ## 配置命令
@@ -55,8 +66,52 @@ strict-dirty-check: true
 modules:
   - name: pixiu-ad-server
     url: git@github.com:commerce/server.git
+
+app-openers:
+  - name: zed
+    app: Zed
+    label: Zed
+    shortcut: z
 ```
+
+## Requirements
+
+### Requirement: Configurable app openers
+
+配置文件 SHALL support an optional `app-openers` list for declaring extra GUI applications that can open the currently selected project path from the TUI operation menu.
+
+#### Scenario: Load Zed opener example
+- **WHEN** `.modu.yaml` contains an `app-openers` entry with `name: zed`, `app: Zed`, `label: Zed`, and `shortcut: z`
+- **THEN** config loading succeeds and exposes an app opener whose display text can be rendered as "打开 Zed" with shortcut `z`
+
+#### Scenario: Missing app openers remains compatible
+- **WHEN** `.modu.yaml` does not contain `app-openers`
+- **THEN** config loading succeeds and the TUI uses only built-in operation menu items
+
+#### Scenario: App opener without shortcut
+- **WHEN** an `app-openers` entry omits `shortcut`
+- **THEN** config loading succeeds and the opener is available for menu selection without a direct shortcut key
+
+### Requirement: App opener config validation
+
+Each configured app opener MUST include enough information to identify the app and MUST use a valid shortcut shape when a shortcut is provided.
+
+#### Scenario: Missing opener name is invalid
+- **WHEN** an `app-openers` entry has an empty `name`
+- **THEN** config loading fails with `ERR_CONFIG_INVALID`
+
+#### Scenario: Missing app name is invalid
+- **WHEN** an `app-openers` entry has an empty `app`
+- **THEN** config loading fails with `ERR_CONFIG_INVALID`
+
+#### Scenario: Shortcut must be a single printable key
+- **WHEN** an `app-openers` entry sets `shortcut` to more than one character or to a non-printable key
+- **THEN** config loading fails with `ERR_CONFIG_INVALID`
+
+#### Scenario: Shortcut conflict does not invalidate config
+- **WHEN** an `app-openers` entry sets `shortcut: c` and `c` is already used by a built-in TUI menu action
+- **THEN** config loading still succeeds because shortcut conflict resolution is handled by the TUI menu
 
 ## 与代码的对应
 
-- 实现：`internal/config`（Config、Module、LoadConfig、LoadConfigForScan、validate、validateBasic）。
+- 实现：`internal/config`（Config、Module、AppOpener、LoadConfig、LoadConfigForScan、validate、validateBasic）。

--- a/openspec/specs/config/spec.md
+++ b/openspec/specs/config/spec.md
@@ -34,7 +34,7 @@
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | `name` | string | 是 | 配置项标识 |
-| `app` | string | 是 | macOS `open -a` 使用的应用名称 |
+| `app` | string | 是 | macOS“应用程序”中的应用名称，例如 VS Code 应填 `Visual Studio Code`，而不是 `vscode` 或 CLI 命令 `code` |
 | `label` | string | 否 | 操作菜单展示名称；为空时使用 `app` |
 | `shortcut` | string | 否 | 操作菜单直接执行快捷键，必须是单个可打印字符 |
 
@@ -78,7 +78,7 @@ app-openers:
 
 ### Requirement: Configurable app openers
 
-配置文件 SHALL support an optional `app-openers` list for declaring extra GUI applications that can open the currently selected project path from the TUI operation menu.
+配置文件 SHALL support an optional `app-openers` list for declaring extra GUI applications that can open the currently selected project path from the TUI operation menu. Each opener's `app` field SHALL use the macOS application name as shown in Applications, not a short alias or CLI command.
 
 #### Scenario: Load Zed opener example
 - **WHEN** `.modu.yaml` contains an `app-openers` entry with `name: zed`, `app: Zed`, `label: Zed`, and `shortcut: z`

--- a/openspec/specs/tui/spec.md
+++ b/openspec/specs/tui/spec.md
@@ -2,7 +2,7 @@
 
 **版本**: 2.4 | **来源**: docs/plans/2026-03-06-modu-design-v2.4.md
 
-## 目的
+## Purpose
 
 基于 Bubble Tea 的状态机 TUI，提供 worktree 列表查看、创建/删除 worktree，删除前二次确认。
 
@@ -31,19 +31,29 @@
 ## 与代码的对应
 
 - 实现：`internal/ui`（Bubble Tea 模型、状态转换）；`internal/ui/config_wizard.go`（配置向导）。
-
-## 操作菜单
-
+## Requirements
 ### Requirement: 操作菜单显示
-用户按 Enter 后，TUI SHALL 显示操作菜单，包含可用的操作选项。
+用户按 Enter 后，TUI SHALL 显示操作菜单，包含内置操作选项，以及当前机器已安装的配置化 app opener。
 
 #### Scenario: 进入操作菜单
 - **WHEN** 用户在列表视图按 Enter
 - **THEN** TUI 显示操作菜单，当前选中第一项（打开 VS Code）
 
-#### Scenario: 操作菜单显示正确选项
-- **WHEN** 操作菜单显示
-- **THEN** 显示"打开 VS Code"和"删除"两个选项（打开在前，删除在后）
+#### Scenario: feature 操作菜单显示内置选项
+- **WHEN** 用户选中 feature 并进入操作菜单
+- **THEN** 菜单显示内置选项 "打开 VS Code"、"打开 Codex"、"复制路径"、"更新代码"、"Modules 管理" 和 "删除"
+
+#### Scenario: 已安装配置化 app opener 显示在菜单中
+- **WHEN** `.modu.yaml` 配置了 `app: Zed`、`label: Zed`、`shortcut: z` 的 app opener 且当前机器已安装 Zed
+- **THEN** 操作菜单显示 "打开 Zed (z)"，位置在内置打开项之后、非打开操作之前
+
+#### Scenario: 未安装配置化 app opener 不显示
+- **WHEN** `.modu.yaml` 配置了 `app: Cursor` 的 app opener 但当前机器未安装 Cursor
+- **THEN** 操作菜单不显示 "打开 Cursor"
+
+#### Scenario: 冲突快捷键不显示
+- **WHEN** `.modu.yaml` 配置了 `app: Cursor`、`label: Cursor`、`shortcut: c` 且 Cursor 已安装
+- **THEN** 操作菜单显示 "打开 Cursor" 且不显示 "(c)"，因为 `c` 已被复制路径占用
 
 ### Requirement: 操作菜单导航
 用户 MUST 可以在操作菜单中使用上下键选择不同的操作。
@@ -57,7 +67,7 @@
 - **THEN** 选中项向下移动一项
 
 ### Requirement: 操作菜单执行操作
-用户 MUST 可以选择操作并执行。
+用户 MUST 可以选择操作并执行；配置化 app opener 在可见时 MUST 支持 Enter 执行，并且仅在快捷键未冲突时支持直接按键执行。
 
 #### Scenario: Enter 执行选中操作
 - **WHEN** 用户在操作菜单按 Enter
@@ -71,6 +81,22 @@
 - **WHEN** 用户在操作菜单选中"打开 VS Code"项并按 o
 - **THEN** 在 VS Code 中打开主项目，然后返回列表视图
 
+#### Scenario: Enter 执行配置化 app opener
+- **WHEN** 用户在操作菜单选中 "打开 Zed (z)" 并按 Enter
+- **THEN** TUI 使用配置的 app 名称打开当前选中条目的主项目路径，然后返回列表视图
+
+#### Scenario: 唯一快捷键执行配置化 app opener
+- **WHEN** 用户在操作菜单按下配置化 app opener 的唯一快捷键 `z`
+- **THEN** TUI 使用该 opener 的 app 名称打开当前选中条目的主项目路径，然后返回列表视图
+
+#### Scenario: 冲突快捷键不执行配置化 app opener
+- **WHEN** Cursor opener 配置了冲突快捷键 `c` 且用户在操作菜单按 `c`
+- **THEN** TUI 执行内置复制路径操作，而不是打开 Cursor
+
+#### Scenario: 配置化 app opener 缺少可打开路径
+- **WHEN** 用户对没有主项目路径的 feature 执行配置化 app opener
+- **THEN** TUI 进入错误状态并显示无法打开的中文错误信息
+
 #### Scenario: 退出操作菜单
 - **WHEN** 用户在操作菜单按 esc 或 q
 - **THEN** TUI 返回列表视图
@@ -81,6 +107,106 @@
 #### Scenario: 直接删除
 - **WHEN** 用户在列表视图按 d
 - **THEN** TUI 进入删除确认状态，显示待删除的特征名
+
+### Requirement: TUI feature creation entry
+The TUI SHALL provide a list-view action for starting feature creation without changing existing list navigation, open, update, copy, module-management, delete, or quit shortcuts.
+
+#### Scenario: Start creation from list view
+- **WHEN** the user is in the list view and presses `n`
+- **THEN** the TUI enters the feature-name input state for creating a new feature
+
+#### Scenario: Existing quit shortcut remains in list view
+- **WHEN** the user is in the list view and presses `q`
+- **THEN** the TUI exits as before
+
+#### Scenario: Create shortcut is shown
+- **WHEN** the TUI renders the list view
+- **THEN** the shortcut help includes the Chinese create-feature action
+
+### Requirement: Editable feature-name input
+The TUI SHALL let users enter and edit the feature name with cursor movement before selecting projects/modules.
+
+#### Scenario: Printable character insertion
+- **WHEN** the user types printable characters in the feature-name input state
+- **THEN** the characters are inserted at the current cursor position and the cursor moves after the inserted text
+
+#### Scenario: Cursor movement
+- **WHEN** the user presses left, right, home, or end in the feature-name input state
+- **THEN** the input cursor moves within the feature-name text without leaving the input state
+
+#### Scenario: In-place deletion
+- **WHEN** the user presses backspace or delete in the feature-name input state
+- **THEN** the TUI removes text adjacent to the cursor without leaving the input state
+
+#### Scenario: q is normal input text
+- **WHEN** the user presses `q` in the feature-name input state
+- **THEN** the TUI inserts `q` into the feature name and MUST NOT quit or cancel input
+
+#### Scenario: Empty name is rejected
+- **WHEN** the user presses Enter while the feature-name input is empty or whitespace-only
+- **THEN** the TUI remains in the feature-name input state and shows a Chinese validation message
+
+#### Scenario: Cancel feature-name input
+- **WHEN** the user presses Esc or Ctrl+C in the feature-name input state
+- **THEN** the TUI cancels creation and returns to the list view without creating a worktree
+
+### Requirement: Project selection before creation
+The TUI SHALL provide a project/module selection step after the user confirms a feature name and before any worktree creation starts.
+
+#### Scenario: Open selection after valid name
+- **WHEN** the user enters a non-empty feature name and presses Enter
+- **THEN** the TUI displays a selection view for configured projects/modules before creating the feature
+
+#### Scenario: Main project is included
+- **WHEN** the user reaches the project/module selection step
+- **THEN** the main project is treated as always included for feature creation
+
+#### Scenario: Configured modules are selectable
+- **WHEN** the project/module selection step is displayed
+- **THEN** each configured module is shown as selectable and can be toggled before confirmation
+
+#### Scenario: Default and remote branch preselection
+- **WHEN** configured default-selected modules or modules with the target remote branch exist
+- **THEN** those modules are preselected in the project/module selection step
+
+#### Scenario: Selection cancellation
+- **WHEN** the user cancels the project/module selection step
+- **THEN** the TUI returns to the list view without creating a worktree
+
+### Requirement: Create feature from TUI selection
+The TUI SHALL create the feature worktree after the user confirms project/module selection.
+
+#### Scenario: Create selected projects
+- **WHEN** the user confirms project/module selection for a feature name
+- **THEN** the TUI creates the main project worktree and only the selected module worktrees
+
+#### Scenario: Create with no selected modules
+- **WHEN** the user confirms creation with no modules selected
+- **THEN** the TUI creates the main project feature worktree without module worktrees
+
+#### Scenario: Creation success feedback
+- **WHEN** feature creation succeeds
+- **THEN** the TUI reloads the list view and shows a Chinese success message containing the feature name
+
+#### Scenario: Creation failure feedback
+- **WHEN** feature creation fails
+- **THEN** the TUI enters the error state and shows the creation error
+
+### Requirement: App opener availability detection
+
+TUI SHALL determine configured app opener visibility at startup by checking whether each configured app can be resolved on the current machine.
+
+#### Scenario: Installed app is available
+- **WHEN** a configured app opener refers to an installed app
+- **THEN** TUI includes that opener in the operation menu
+
+#### Scenario: Missing app is unavailable
+- **WHEN** a configured app opener refers to an app that is not installed or cannot be resolved
+- **THEN** TUI excludes that opener from the operation menu without entering the error state
+
+#### Scenario: Availability is evaluated before rendering menu
+- **WHEN** the TUI first enters the list view after startup
+- **THEN** the operation menu model already contains only available configured app openers
 
 ## 用户可见文案（中文）
 


### PR DESCRIPTION
在 TUI 操作菜单中接入配置化 app-openers，并补齐 feature 创建入口、模块选择与相关 OpenSpec 归档。配置层保留冲突快捷键，由 TUI 在可见菜单中解析绑定，避免配置文件因本机快捷键差异失败。

Constraint: 操作菜单需要兼容既有 VS Code、Codex、复制、更新、Modules 和删除快捷键

Constraint: App 可用性基于 macOS open -Ra 检测，未安装时不展示

Rejected: 在配置加载阶段禁止快捷键冲突 - 冲突取决于 TUI 内置菜单和可见 app，放在菜单层处理更稳妥

Confidence: high

Scope-risk: moderate

Directive: 修改操作菜单快捷键时同步更新内置快捷键集合和 app opener 冲突测试

Tested: pre-commit run --all-files

Tested: GOCACHE=/private/tmp/modu-go-build-cache go test -count=1 ./...

Tested: openspec validate config --strict

Tested: openspec validate tui --strict

Not-tested: macOS 实机打开第三方 app 的人工交互验证
