### PR TITLE
feat: 删除 worktree 前保护未推送分支

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docs/temp/
 dist/
 
 .pi
+cmd/modu/modu

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ modu info my-feature
 # 删除 worktree
 modu delete my-feature
 modu delete my-feature --force  # 强制删除（跳过脏检查）
+modu delete my-feature --allow-unpushed  # 确认删除未推送到远端的本地分支
 
 # 设置默认选中的模块（创建 feature 时会默认选中这些模块）
 modu default-select

--- a/cmd/modu/main.go
+++ b/cmd/modu/main.go
@@ -98,6 +98,7 @@ func main() {
 		Run:   runDelete,
 	}
 	deleteCmd.Flags().BoolP("force", "f", false, "强制删除（跳过脏检查）")
+	deleteCmd.Flags().Bool("allow-unpushed", false, "允许删除未推送到远端的本地分支")
 
 	// default-select 命令 - 设置默认选中的模块
 	defaultSelectCmd := &cobra.Command{
@@ -407,11 +408,30 @@ func runCreate(cmd *cobra.Command, args []string) {
 func runDelete(cmd *cobra.Command, args []string) {
 	feature := args[0]
 	force, _ := cmd.Flags().GetBool("force")
+	allowUnpushedBranches, _ := cmd.Flags().GetBool("allow-unpushed")
 
 	eng := loadConfig()
 	formatter := output.New(outputFmt)
 
-	err := eng.DeleteWorktree(cmd.Context(), feature, force)
+	unpushedBranches, err := eng.CheckDeleteUnpushedBranches(cmd.Context(), feature)
+	if err != nil {
+		fmt.Print(formatter.FormatError(errors.Code(err), err.Error(), nil))
+		os.Exit(1)
+	}
+
+	if len(unpushedBranches) > 0 && !allowUnpushedBranches {
+		data := map[string]interface{}{
+			"feature":  feature,
+			"branches": unpushedBranches,
+		}
+		message := fmt.Sprintf("cannot delete feature %s: unpushed branches detected, rerun with --allow-unpushed to confirm deletion", feature)
+		fmt.Print(formatter.FormatError(errors.Code(errors.ErrUnpushedBranch), message, data))
+		os.Exit(1)
+	}
+
+	err = eng.DeleteWorktreeWithOptions(cmd.Context(), feature, force, engine.DeleteOptions{
+		AllowUnpushedBranches: allowUnpushedBranches,
+	})
 	if err != nil {
 		fmt.Print(formatter.FormatError(errors.Code(err), err.Error(), nil))
 		os.Exit(1)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -32,6 +32,22 @@ type MainProjectStatus struct {
 	Branch  string
 }
 
+// UnpushedBranch 描述删除时会移除、但未确认已推送的本地分支。
+type UnpushedBranch struct {
+	Name         string `json:"name"`
+	RepoPath     string `json:"repoPath"`
+	WorktreePath string `json:"worktreePath"`
+	Branch       string `json:"branch"`
+	RemoteRef    string `json:"remoteRef,omitempty"`
+	AheadCount   int    `json:"aheadCount,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+}
+
+// DeleteOptions 控制 feature 删除中的危险操作是否已被外层确认。
+type DeleteOptions struct {
+	AllowUnpushedBranches bool
+}
+
 // worktreeResult 创建工作树的结果
 type worktreeResult struct {
 	module   config.Module
@@ -433,8 +449,89 @@ func (e *Engine) CheckDirty(ctx context.Context, env core.WorktreeEnv) ([]core.M
 	return dirty, nil
 }
 
+// CheckDeleteUnpushedBranches 返回删除 feature 时需要人工确认的本地分支。
+func (e *Engine) CheckDeleteUnpushedBranches(ctx context.Context, feature string) ([]UnpushedBranch, error) {
+	dirName := featureToDirName(feature)
+	featurePath := filepath.Join(e.Config.WorktreeRoot, dirName)
+	if _, err := os.Stat(featurePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("feature %s not found: %w", feature, errs.ErrFeatureNotFound)
+	}
+
+	entries, err := os.ReadDir(featurePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read feature directory: %w", err)
+	}
+
+	var risks []UnpushedBranch
+	configuredNames := e.configuredModuleNames()
+	for _, entry := range entries {
+		if !entry.IsDir() || !configuredNames[entry.Name()] {
+			continue
+		}
+		moduleName := entry.Name()
+		modulePath := filepath.Join(featurePath, moduleName)
+		repoPath := filepath.Join(e.Config.Workspace, moduleName)
+		if _, err := os.Stat(repoPath); os.IsNotExist(err) {
+			continue
+		}
+		risks = e.appendUnpushedBranchRisk(ctx, risks, moduleName, repoPath, modulePath, dirName)
+	}
+
+	if _, err := os.Stat(e.Config.Workspace); !os.IsNotExist(err) {
+		risks = e.appendUnpushedBranchRisk(ctx, risks, "main", e.Config.Workspace, featurePath, dirName)
+	}
+	return risks, nil
+}
+
+// appendUnpushedBranchRisk 将单个 worktree 的未推送风险追加到列表中。
+func (e *Engine) appendUnpushedBranchRisk(ctx context.Context, risks []UnpushedBranch, name, repoPath, worktreePath, featureDirName string) []UnpushedBranch {
+	status, err := e.GitProxy.GetStatus(ctx, worktreePath)
+	if err != nil {
+		logger.Warn("无法读取 worktree 分支状态，跳过未推送检查: path=%s, err=%v", worktreePath, err)
+		return risks
+	}
+
+	branch := strings.TrimSpace(status.Branch)
+	if branch == "" || branch == "HEAD" || branchToFeatureDirName(branch) != featureDirName {
+		return risks
+	}
+
+	pushStatus, err := e.GitProxy.GetBranchPushStatus(ctx, repoPath, branch)
+	if err != nil {
+		return append(risks, UnpushedBranch{
+			Name:         name,
+			RepoPath:     repoPath,
+			WorktreePath: worktreePath,
+			Branch:       branch,
+			Reason:       err.Error(),
+		})
+	}
+	if pushStatus.IsPushed {
+		return risks
+	}
+	return append(risks, UnpushedBranch{
+		Name:         name,
+		RepoPath:     repoPath,
+		WorktreePath: worktreePath,
+		Branch:       branch,
+		RemoteRef:    pushStatus.RemoteRef,
+		AheadCount:   pushStatus.AheadCount,
+		Reason:       pushStatus.Reason,
+	})
+}
+
+// branchToFeatureDirName 将分支名转换成 feature 目录名。
+func branchToFeatureDirName(branch string) string {
+	return strings.ReplaceAll(branch, "/", "-")
+}
+
 // DeleteWorktree 删除 feature 工作树
 func (e *Engine) DeleteWorktree(ctx context.Context, feature string, force bool) error {
+	return e.DeleteWorktreeWithOptions(ctx, feature, force, DeleteOptions{})
+}
+
+// DeleteWorktreeWithOptions 删除 feature 工作树，并允许外层传入已确认的危险操作选项。
+func (e *Engine) DeleteWorktreeWithOptions(ctx context.Context, feature string, force bool, options DeleteOptions) error {
 	logger.Info("开始删除 feature: %s, force: %v", feature, force)
 
 	// 将 feature 名转换为目录名（feature/hello → feature-hello）
@@ -474,6 +571,16 @@ func (e *Engine) DeleteWorktree(ctx context.Context, feature string, force bool)
 		}
 		if len(dirty) > 0 {
 			return fmt.Errorf("cannot delete: uncommitted changes detected in %v: %w", dirty, errs.ErrDirtyWorktree)
+		}
+	}
+
+	if !options.AllowUnpushedBranches {
+		risks, err := e.CheckDeleteUnpushedBranches(ctx, feature)
+		if err != nil {
+			return err
+		}
+		if len(risks) > 0 {
+			return fmt.Errorf("cannot delete: unpushed branches detected: %w", errs.ErrUnpushedBranch)
 		}
 	}
 
@@ -1023,6 +1130,11 @@ func (e *Engine) AddModule(ctx context.Context, feature, moduleName string) erro
 
 // RemoveModule 为 feature 删除单个模块的 worktree
 func (e *Engine) RemoveModule(ctx context.Context, feature, moduleName string) error {
+	return e.RemoveModuleWithOptions(ctx, feature, moduleName, DeleteOptions{})
+}
+
+// RemoveModuleWithOptions 删除单个模块 worktree，并允许外层传入已确认的危险操作选项。
+func (e *Engine) RemoveModuleWithOptions(ctx context.Context, feature, moduleName string, options DeleteOptions) error {
 	logger.Info("为 feature %s 删除模块: %s", feature, moduleName)
 
 	// 将 feature 名转换为目录名（feature/hello → feature-hello）
@@ -1061,6 +1173,13 @@ func (e *Engine) RemoveModule(ctx context.Context, feature, moduleName string) e
 		}
 		logger.Info("成功删除模块目录: feature=%s, module=%s", feature, moduleName)
 		return nil
+	}
+
+	if !options.AllowUnpushedBranches {
+		risks := e.appendUnpushedBranchRisk(ctx, nil, moduleName, repoPath, modulePath, dirName)
+		if len(risks) > 0 {
+			return fmt.Errorf("cannot remove module %s: unpushed branches detected: %w", moduleName, errs.ErrUnpushedBranch)
+		}
 	}
 
 	if err := e.GitProxy.RemoveWorktreeAndBranch(ctx, repoPath, modulePath, dirName); err != nil {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/qimaotech/modu/internal/config"
 	"github.com/qimaotech/modu/internal/core"
+	errs "github.com/qimaotech/modu/internal/errors"
 	"github.com/qimaotech/modu/internal/gitproxy"
 )
 
@@ -30,6 +31,7 @@ type MockGitClient struct {
 	BranchExistsFunc                     func(ctx context.Context, repoPath, branch string) bool
 	CheckBranchWorktreeStatusFunc        func(ctx context.Context, repoPath, branch string) (bool, error)
 	RemoteBranchExistsFunc               func(ctx context.Context, repoURL, branch string) bool
+	GetBranchPushStatusFunc              func(ctx context.Context, repoPath, branch string) (gitproxy.BranchPushStatus, error)
 }
 
 var _ gitproxy.GitClient = (*MockGitClient)(nil)
@@ -116,6 +118,13 @@ func (m *MockGitClient) RemoteBranchExists(ctx context.Context, repoURL, branch 
 		return m.RemoteBranchExistsFunc(ctx, repoURL, branch)
 	}
 	return false
+}
+
+func (m *MockGitClient) GetBranchPushStatus(ctx context.Context, repoPath, branch string) (gitproxy.BranchPushStatus, error) {
+	if m.GetBranchPushStatusFunc != nil {
+		return m.GetBranchPushStatusFunc(ctx, repoPath, branch)
+	}
+	return gitproxy.BranchPushStatus{Branch: branch, RemoteRef: "origin/" + branch, IsPushed: true}, nil
 }
 
 func (m *MockGitClient) CreateWorktreeFromExistingBranch(ctx context.Context, repoPath, branch, worktreePath string) error {
@@ -988,4 +997,137 @@ func TestAddModule_UsesWorkspaceMetadataForSlugFeature(t *testing.T) {
 	if createdBranch != "feature/demand-pay-cpr" {
 		t.Errorf("expected branch feature/demand-pay-cpr, got %s", createdBranch)
 	}
+}
+
+func TestDeleteWorktree_BlocksUnpushedBranches(t *testing.T) {
+	engine, mock, removedCount := newDeletePreflightTestEngine(t, gitproxy.BranchPushStatus{
+		Branch:     "feat-a",
+		RemoteRef:  "origin/feat-a",
+		IsPushed:   false,
+		AheadCount: 1,
+		Reason:     "1 local commits not pushed",
+	})
+
+	err := engine.DeleteWorktree(context.Background(), "feat-a", false)
+	if !errors.Is(err, errs.ErrUnpushedBranch) {
+		t.Fatalf("expected ErrUnpushedBranch, got %v", err)
+	}
+	if *removedCount != 0 {
+		t.Fatalf("expected no removal before confirmation, got %d", *removedCount)
+	}
+	if mock.GetBranchPushStatusFunc == nil {
+		t.Fatal("expected push status mock to be configured")
+	}
+}
+
+func TestDeleteWorktree_AllowsPushedBranches(t *testing.T) {
+	engine, _, removedCount := newDeletePreflightTestEngine(t, gitproxy.BranchPushStatus{
+		Branch:    "feat-a",
+		RemoteRef: "origin/feat-a",
+		IsPushed:  true,
+	})
+
+	err := engine.DeleteWorktree(context.Background(), "feat-a", false)
+	if err != nil {
+		t.Fatalf("DeleteWorktree() unexpected error: %v", err)
+	}
+	if *removedCount != 2 {
+		t.Fatalf("expected module and main removal, got %d", *removedCount)
+	}
+}
+
+func TestDeleteWorktreeWithOptions_AllowsConfirmedUnpushedBranches(t *testing.T) {
+	engine, _, removedCount := newDeletePreflightTestEngine(t, gitproxy.BranchPushStatus{
+		Branch:     "feat-a",
+		RemoteRef:  "origin/feat-a",
+		IsPushed:   false,
+		AheadCount: 1,
+		Reason:     "1 local commits not pushed",
+	})
+
+	err := engine.DeleteWorktreeWithOptions(context.Background(), "feat-a", false, DeleteOptions{
+		AllowUnpushedBranches: true,
+	})
+	if err != nil {
+		t.Fatalf("DeleteWorktreeWithOptions() unexpected error: %v", err)
+	}
+	if *removedCount != 2 {
+		t.Fatalf("expected module and main removal, got %d", *removedCount)
+	}
+}
+
+func TestCheckDeleteUnpushedBranches_SkipsNonCandidateBranches(t *testing.T) {
+	cfg, _ := newDeletePreflightConfig(t)
+	pushStatusCalled := false
+	mock := &MockGitClient{
+		GetStatusFunc: func(ctx context.Context, path string) (gitproxy.Status, error) {
+			return gitproxy.Status{Branch: "other-branch"}, nil
+		},
+		GetBranchPushStatusFunc: func(ctx context.Context, repoPath, branch string) (gitproxy.BranchPushStatus, error) {
+			pushStatusCalled = true
+			return gitproxy.BranchPushStatus{}, nil
+		},
+	}
+	engine := NewWithClient(cfg, mock)
+
+	risks, err := engine.CheckDeleteUnpushedBranches(context.Background(), "feat-a")
+	if err != nil {
+		t.Fatalf("CheckDeleteUnpushedBranches() unexpected error: %v", err)
+	}
+	if len(risks) != 0 {
+		t.Fatalf("expected no risks for non-candidate branch, got %+v", risks)
+	}
+	if pushStatusCalled {
+		t.Fatal("push status should not be checked for non-candidate branch")
+	}
+}
+
+func newDeletePreflightTestEngine(t *testing.T, pushStatus gitproxy.BranchPushStatus) (*Engine, *MockGitClient, *int) {
+	t.Helper()
+
+	cfg, _ := newDeletePreflightConfig(t)
+	removedCount := 0
+	mock := &MockGitClient{
+		GetStatusFunc: func(ctx context.Context, path string) (gitproxy.Status, error) {
+			return gitproxy.Status{Branch: "feat-a"}, nil
+		},
+		GetBranchPushStatusFunc: func(ctx context.Context, repoPath, branch string) (gitproxy.BranchPushStatus, error) {
+			return pushStatus, nil
+		},
+		RemoveWorktreeAndBranchFunc: func(ctx context.Context, repoPath, worktreePath, featureDirName string) error {
+			removedCount++
+			return nil
+		},
+	}
+	return NewWithClient(cfg, mock), mock, &removedCount
+}
+
+func newDeletePreflightConfig(t *testing.T) (*config.Config, string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	workspace := filepath.Join(tmpDir, "workspace")
+	worktreeRoot := filepath.Join(tmpDir, "worktrees")
+	featurePath := filepath.Join(worktreeRoot, "feat-a")
+
+	for _, path := range []string{
+		workspace,
+		filepath.Join(workspace, "module1"),
+		featurePath,
+		filepath.Join(featurePath, "module1"),
+	} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		Workspace:    workspace,
+		WorktreeRoot: worktreeRoot,
+		StrictDirty:  false,
+		Modules: []config.Module{
+			{Name: "module1", URL: "git@example.com:module1.git"},
+		},
+	}
+	return cfg, featurePath
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrFeatureNotFound  = errors.New("ERR_FEATURE_NOT_FOUND")
 	ErrModuleNotFound   = errors.New("ERR_MODULE_NOT_FOUND")
 	ErrInvalidOperation = errors.New("ERR_INVALID_OPERATION")
+	ErrUnpushedBranch   = errors.New("ERR_UNPUSHED_BRANCH")
 )
 
 // Code 返回错误码字符串
@@ -42,6 +43,9 @@ func Code(err error) string {
 	}
 	if errors.Is(err, ErrInvalidOperation) {
 		return "ERR_INVALID_OPERATION"
+	}
+	if errors.Is(err, ErrUnpushedBranch) {
+		return "ERR_UNPUSHED_BRANCH"
 	}
 	return "ERR_UNKNOWN"
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -57,6 +57,11 @@ func TestCode(t *testing.T) {
 			wantCode: "ERR_INVALID_OPERATION",
 		},
 		{
+			name:     "ErrUnpushedBranch",
+			err:      ErrUnpushedBranch,
+			wantCode: "ERR_UNPUSHED_BRANCH",
+		},
+		{
 			name:     "wrapped error",
 			err:      errors.New("wrapped: " + ErrConfigInvalid.Error()),
 			wantCode: "ERR_UNKNOWN",

--- a/internal/gitproxy/gitproxy.go
+++ b/internal/gitproxy/gitproxy.go
@@ -34,6 +34,8 @@ type GitClient interface {
 	RemoteBranchExists(ctx context.Context, repoURL, branch string) bool
 	// CreateWorktreeFromRemoteBranch 从远程分支创建 worktree（不创建新分支）
 	CreateWorktreeFromRemoteBranch(ctx context.Context, repoPath, branch, worktreePath string) error
+	// GetBranchPushStatus 检查本地分支是否已完整推送到远端分支
+	GetBranchPushStatus(ctx context.Context, repoPath, branch string) (BranchPushStatus, error)
 }
 
 // Status Git 状态
@@ -53,4 +55,13 @@ type FileStatus struct {
 type WorktreeInfo struct {
 	Path   string
 	Branch string
+}
+
+// BranchPushStatus 记录本地分支相对远端分支的推送状态。
+type BranchPushStatus struct {
+	Branch     string `json:"branch"`
+	RemoteRef  string `json:"remoteRef"`
+	IsPushed   bool   `json:"isPushed"`
+	AheadCount int    `json:"aheadCount"`
+	Reason     string `json:"reason,omitempty"`
 }

--- a/internal/gitproxy/gitproxy_impl.go
+++ b/internal/gitproxy/gitproxy_impl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/qimaotech/modu/internal/errors"
@@ -267,6 +268,84 @@ func (g *GitProxy) CreateWorktreeFromRemoteBranch(ctx context.Context, repoPath,
 		return fmt.Errorf("[git worktree add] failed to create worktree from remote branch %s at %s: %w, output: %s", branch, worktreePath, errors.ErrGitExec, string(out))
 	}
 	return nil
+}
+
+// GetBranchPushStatus 检查本地分支是否已完整推送到远端分支。
+func (g *GitProxy) GetBranchPushStatus(ctx context.Context, repoPath, branch string) (BranchPushStatus, error) {
+	branch = strings.TrimSpace(branch)
+	status := BranchPushStatus{Branch: branch}
+	if branch == "" || branch == "HEAD" {
+		status.Reason = "invalid branch"
+		return status, nil
+	}
+
+	if err := g.Fetch(ctx, repoPath); err != nil {
+		status.Reason = "fetch failed"
+		return status, fmt.Errorf("[git fetch] failed to inspect push status for branch %s in %s: %w", branch, repoPath, err)
+	}
+
+	remoteRef, found, err := g.resolveBranchRemoteRef(ctx, repoPath, branch)
+	if err != nil {
+		status.Reason = "remote lookup failed"
+		return status, err
+	}
+	if !found {
+		status.Reason = "remote branch not found"
+		return status, nil
+	}
+	status.RemoteRef = remoteRef
+
+	aheadCount, err := g.countBranchAhead(ctx, repoPath, remoteRef, branch)
+	if err != nil {
+		status.Reason = "ahead count failed"
+		return status, err
+	}
+	status.AheadCount = aheadCount
+	status.IsPushed = aheadCount == 0
+	if aheadCount > 0 {
+		status.Reason = fmt.Sprintf("%d local commits not pushed", aheadCount)
+	}
+	return status, nil
+}
+
+// resolveBranchRemoteRef 优先使用 upstream，否则回退到 origin/<branch>。
+func (g *GitProxy) resolveBranchRemoteRef(ctx context.Context, repoPath, branch string) (string, bool, error) {
+	upstreamArg := branch + "@{upstream}"
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--abbrev-ref", upstreamArg)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		remoteRef := strings.TrimSpace(string(out))
+		if remoteRef != "" {
+			return remoteRef, true, nil
+		}
+	}
+
+	fallbackRemoteRef := "origin/" + branch
+	verifyRef := "refs/remotes/" + fallbackRemoteRef
+	cmd = exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--verify", "--quiet", verifyRef)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return "", false, nil
+	}
+	if strings.TrimSpace(string(out)) == "" {
+		return "", false, nil
+	}
+	return fallbackRemoteRef, true, nil
+}
+
+// countBranchAhead 返回 local branch 相对 remoteRef 的领先提交数。
+func (g *GitProxy) countBranchAhead(ctx context.Context, repoPath, remoteRef, branch string) (int, error) {
+	revisionRange := remoteRef + ".." + branch
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-list", "--count", revisionRange)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("[git rev-list] failed to count ahead commits for %s in %s: %w, output: %s", branch, repoPath, errors.ErrGitExec, string(out))
+	}
+	aheadCount, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("[git rev-list] invalid ahead count for %s in %s: %w, output: %s", branch, repoPath, err, string(out))
+	}
+	return aheadCount, nil
 }
 
 // CheckBranchWorktreeStatus 检查分支是否已被 worktree 使用

--- a/internal/gitproxy/gitproxy_test.go
+++ b/internal/gitproxy/gitproxy_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestParseStatus(t *testing.T) {
 	tests := []struct {
-		name           string
-		output         string
-		path           string
-		wantIsDirty    bool
-		wantBranch     string
-		wantFileCount  int
+		name          string
+		output        string
+		path          string
+		wantIsDirty   bool
+		wantBranch    string
+		wantFileCount int
 	}{
 		{
 			name:          "clean working tree",
@@ -116,7 +116,7 @@ func TestParseWorktreeList(t *testing.T) {
 			wantFirstBranch: "main",
 		},
 		{
-			name:            "multiple worktrees",
+			name: "multiple worktrees",
 			output: `worktree /home/user/repos/main
 HEAD abcd1234
 branch refs/heads/main
@@ -258,5 +258,97 @@ func TestRemoteBranchExists_NetworkError(t *testing.T) {
 	exists := g.RemoteBranchExists(context.Background(), "git@192.0.2.1:nonexistent/repo.git", "main")
 	if exists {
 		t.Error("expected false for network error")
+	}
+}
+
+func TestGetBranchPushStatus_Pushed(t *testing.T) {
+	repoPath := setupPushStatusRepo(t, "feature/test")
+
+	g := &GitProxy{}
+	status, err := g.GetBranchPushStatus(context.Background(), repoPath, "feature/test")
+	if err != nil {
+		t.Fatalf("GetBranchPushStatus() unexpected error: %v", err)
+	}
+	if !status.IsPushed {
+		t.Fatalf("IsPushed = false, want true: %+v", status)
+	}
+	if status.AheadCount != 0 {
+		t.Fatalf("AheadCount = %d, want 0", status.AheadCount)
+	}
+}
+
+func TestGetBranchPushStatus_AheadOfRemote(t *testing.T) {
+	repoPath := setupPushStatusRepo(t, "feature/test")
+	writeCommit(t, repoPath, "local.txt", "local change", "local change")
+
+	g := &GitProxy{}
+	status, err := g.GetBranchPushStatus(context.Background(), repoPath, "feature/test")
+	if err != nil {
+		t.Fatalf("GetBranchPushStatus() unexpected error: %v", err)
+	}
+	if status.IsPushed {
+		t.Fatalf("IsPushed = true, want false: %+v", status)
+	}
+	if status.AheadCount != 1 {
+		t.Fatalf("AheadCount = %d, want 1", status.AheadCount)
+	}
+}
+
+func TestGetBranchPushStatus_MissingRemoteBranch(t *testing.T) {
+	repoPath := setupPushStatusRepo(t, "feature/test")
+	runGit(t, repoPath, "checkout", "-b", "local-only")
+	writeCommit(t, repoPath, "local-only.txt", "local only", "local only")
+
+	g := &GitProxy{}
+	status, err := g.GetBranchPushStatus(context.Background(), repoPath, "local-only")
+	if err != nil {
+		t.Fatalf("GetBranchPushStatus() unexpected error: %v", err)
+	}
+	if status.IsPushed {
+		t.Fatalf("IsPushed = true, want false: %+v", status)
+	}
+	if status.Reason == "" {
+		t.Fatalf("Reason should explain missing remote branch: %+v", status)
+	}
+}
+
+func setupPushStatusRepo(t *testing.T, branch string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	remotePath := filepath.Join(tmpDir, "remote.git")
+	repoPath := filepath.Join(tmpDir, "repo")
+
+	runGit(t, "", "init", "--bare", remotePath)
+	runGit(t, "", "clone", remotePath, repoPath)
+	runGit(t, repoPath, "config", "user.name", "modu test")
+	runGit(t, repoPath, "config", "user.email", "modu@example.com")
+	runGit(t, repoPath, "checkout", "-b", branch)
+	writeCommit(t, repoPath, "README.md", "initial", "initial")
+	runGit(t, repoPath, "push", "-u", "origin", branch)
+
+	return repoPath
+}
+
+func writeCommit(t *testing.T, repoPath, fileName, content, message string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(repoPath, fileName), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repoPath, "add", fileName)
+	runGit(t, repoPath, "commit", "-m", message)
+}
+
+func runGit(t *testing.T, repoPath string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v, output: %s", args, err, string(out))
 	}
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -136,15 +136,16 @@ func (e *FeatureEntry) GetDirtyCount() int {
 
 // TUI App 状态
 type App struct {
-	Engine       *engine.Engine
-	Envs         []core.WorktreeEnv
-	mainProject  *engine.MainProjectStatus
-	selected     int
-	menuSelected int    // 操作菜单选中项
-	state        string // "loading", "list", "menu", "modules", "confirm", "error"
-	feature      string
-	err          error
-	message      string
+	Engine           *engine.Engine
+	Envs             []core.WorktreeEnv
+	mainProject      *engine.MainProjectStatus
+	selected         int
+	menuSelected     int    // 操作菜单选中项
+	state            string // "loading", "list", "menu", "modules", "confirm", "confirm_unpushed", "error"
+	feature          string
+	err              error
+	message          string
+	unpushedBranches []engine.UnpushedBranch
 	// 配置化 App 打开工具
 	availableAppOpeners []config.AppOpener
 	appOpenersResolved  bool
@@ -262,6 +263,8 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleCreateModulesKey(msg)
 		case "confirm":
 			return m.handleConfirmKey(msg)
+		case "confirm_unpushed":
+			return m.handleUnpushedConfirmKey(msg)
 		case "error":
 			m.state = "list"
 			m.err = nil
@@ -578,20 +581,51 @@ func (m *App) openAppByName(appName string) {
 func (m *App) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "y", "enter":
-		err := m.Engine.DeleteWorktree(context.Background(), m.feature, false)
+		branches, err := m.Engine.CheckDeleteUnpushedBranches(context.Background(), m.feature)
 		if err != nil {
 			m.err = err
 			m.state = "error"
-		} else {
-			m.message = "已删除 feature: " + m.feature
-			m.state = "loading"
-			m.selected = 0
-			return m, m.loadEnvs
+			return m, nil
 		}
+		if len(branches) > 0 {
+			m.unpushedBranches = branches
+			m.state = "confirm_unpushed"
+			return m, nil
+		}
+		return m.deleteFeature(false)
 	case "n", "esc":
 		m.state = "list"
 	}
 	return m, nil
+}
+
+// handleUnpushedConfirmKey 处理未推送分支风险确认。
+func (m *App) handleUnpushedConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "enter":
+		return m.deleteFeature(true)
+	case "n", "esc":
+		m.unpushedBranches = nil
+		m.state = "list"
+	}
+	return m, nil
+}
+
+// deleteFeature 执行 feature 删除并刷新列表。
+func (m *App) deleteFeature(allowUnpushedBranches bool) (tea.Model, tea.Cmd) {
+	err := m.Engine.DeleteWorktreeWithOptions(context.Background(), m.feature, false, engine.DeleteOptions{
+		AllowUnpushedBranches: allowUnpushedBranches,
+	})
+	if err != nil {
+		m.err = err
+		m.state = "error"
+		return m, nil
+	}
+	m.message = "已删除 feature: " + m.feature
+	m.unpushedBranches = nil
+	m.state = "loading"
+	m.selected = 0
+	return m, m.loadEnvs
 }
 
 // initModuleSelector 初始化模块选择器
@@ -918,6 +952,8 @@ func (m *App) View() string {
 		return m.renderCreateModules()
 	case "confirm":
 		return m.renderConfirm()
+	case "confirm_unpushed":
+		return m.renderUnpushedConfirm()
 	case "error":
 		return m.renderError()
 	default:
@@ -1019,6 +1055,24 @@ func (m *App) renderConfirm() string {
 	s.WriteString("\n\n")
 	s.WriteString(fmt.Sprintf("确定要删除 feature「%s」吗？\n", m.feature))
 	s.WriteString(itemStyle.Render("按 y 确认，n 取消"))
+	s.WriteString("\n\n")
+	return s.String()
+}
+
+func (m *App) renderUnpushedConfirm() string {
+	var s strings.Builder
+	s.WriteString(headerStyle.Render("确认删除未推送分支"))
+	s.WriteString("\n\n")
+	s.WriteString(fmt.Sprintf("feature「%s」包含尚未确认推送到远程的本地分支：\n\n", m.feature))
+	for _, branch := range m.unpushedBranches {
+		reason := branch.Reason
+		if reason == "" {
+			reason = "not pushed"
+		}
+		s.WriteString(fmt.Sprintf("- %s: %s (%s)\n", branch.Name, branch.Branch, reason))
+	}
+	s.WriteString("\n")
+	s.WriteString(itemStyle.Render("按 y 删除本地分支，n 取消"))
 	s.WriteString("\n\n")
 	return s.String()
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -368,6 +368,66 @@ func TestApp_View_Confirm(t *testing.T) {
 	}
 }
 
+// TestApp_View_UnpushedConfirm 未推送分支确认视图包含风险分支
+func TestApp_View_UnpushedConfirm(t *testing.T) {
+	app := &App{
+		state:   "confirm_unpushed",
+		feature: "feat-a",
+		unpushedBranches: []engine.UnpushedBranch{
+			{Name: "module1", Branch: "feat-a", Reason: "1 local commits not pushed"},
+		},
+	}
+	view := app.renderUnpushedConfirm()
+	if !strings.Contains(view, "确认删除未推送分支") || !strings.Contains(view, "module1") {
+		t.Fatalf("renderUnpushedConfirm() missing risk details: %q", view)
+	}
+}
+
+// TestApp_UnpushedConfirm_Cancel 取消未推送确认不执行删除
+func TestApp_UnpushedConfirm_Cancel(t *testing.T) {
+	app, fake := newDeleteRiskTestApp(t)
+	app.state = "confirm_unpushed"
+	app.unpushedBranches = []engine.UnpushedBranch{{Name: "module1", Branch: "feat-a"}}
+
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	if cmd != nil {
+		t.Fatal("取消未推送确认不应返回命令")
+	}
+	if app.state != "list" {
+		t.Fatalf("state = %q, want list", app.state)
+	}
+	if fake.removeCalls != 0 {
+		t.Fatalf("取消后不应删除，removeCalls=%d", fake.removeCalls)
+	}
+}
+
+// TestApp_DeleteFlow_UnpushedConfirmThenDelete 未推送分支需要二次确认后删除
+func TestApp_DeleteFlow_UnpushedConfirmThenDelete(t *testing.T) {
+	app, fake := newDeleteRiskTestApp(t)
+
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd != nil {
+		t.Fatal("进入未推送确认不应立即返回删除命令")
+	}
+	if app.state != "confirm_unpushed" {
+		t.Fatalf("state = %q, want confirm_unpushed", app.state)
+	}
+	if fake.removeCalls != 0 {
+		t.Fatalf("二次确认前不应删除，removeCalls=%d", fake.removeCalls)
+	}
+
+	_, cmd = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd == nil {
+		t.Fatal("确认删除后应返回刷新列表命令")
+	}
+	if app.state != "loading" {
+		t.Fatalf("state = %q, want loading", app.state)
+	}
+	if fake.removeCalls != 2 {
+		t.Fatalf("期望删除模块和主项目，removeCalls=%d", fake.removeCalls)
+	}
+}
+
 // TestApp_View_Error 错误状态视图包含错误信息
 func TestApp_View_Error(t *testing.T) {
 	app := &App{state: "error", err: nil}
@@ -962,6 +1022,54 @@ func newCreateFeatureTestApp(t *testing.T) (*App, *uiFakeGitClient) {
 	return app, fake
 }
 
+func newDeleteRiskTestApp(t *testing.T) (*App, *uiFakeGitClient) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	workspace := filepath.Join(tmpDir, "workspace")
+	worktreeRoot := filepath.Join(tmpDir, "worktrees")
+	featurePath := filepath.Join(worktreeRoot, "feat-a")
+	moduleRepoPath := filepath.Join(workspace, "module1")
+	moduleWorktreePath := filepath.Join(featurePath, "module1")
+	for _, path := range []string{workspace, moduleRepoPath, featurePath, moduleWorktreePath} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fake := &uiFakeGitClient{
+		pushStatuses: map[string]gitproxy.BranchPushStatus{
+			workspace + "|feat-a": {
+				Branch:     "feat-a",
+				RemoteRef:  "origin/feat-a",
+				IsPushed:   false,
+				AheadCount: 1,
+				Reason:     "1 local commits not pushed",
+			},
+			moduleRepoPath + "|feat-a": {
+				Branch:     "feat-a",
+				RemoteRef:  "origin/feat-a",
+				IsPushed:   false,
+				AheadCount: 1,
+				Reason:     "1 local commits not pushed",
+			},
+		},
+	}
+	cfg := &config.Config{
+		Workspace:    workspace,
+		WorktreeRoot: worktreeRoot,
+		Modules: []config.Module{
+			{Name: "module1", URL: "git@example.com:module1.git"},
+		},
+	}
+	app := &App{
+		Engine:  engine.NewWithClient(cfg, fake),
+		state:   "confirm",
+		feature: "feat-a",
+	}
+	return app, fake
+}
+
 type uiFakeCreateWorktreeCall struct {
 	repoPath     string
 	branch       string
@@ -971,7 +1079,9 @@ type uiFakeCreateWorktreeCall struct {
 
 type uiFakeGitClient struct {
 	remoteBranches      map[string]bool
+	pushStatuses        map[string]gitproxy.BranchPushStatus
 	createWorktreeCalls []uiFakeCreateWorktreeCall
+	removeCalls         int
 }
 
 func (f *uiFakeGitClient) Clone(ctx context.Context, url, path string) error {
@@ -997,6 +1107,7 @@ func (f *uiFakeGitClient) RemoveWorktree(ctx context.Context, path string) error
 }
 
 func (f *uiFakeGitClient) RemoveWorktreeAndBranch(ctx context.Context, repoPath, worktreePath, featureDirName string) error {
+	f.removeCalls++
 	return nil
 }
 
@@ -1037,4 +1148,13 @@ func (f *uiFakeGitClient) RemoteBranchExists(ctx context.Context, repoURL, branc
 
 func (f *uiFakeGitClient) CreateWorktreeFromRemoteBranch(ctx context.Context, repoPath, branch, worktreePath string) error {
 	return os.MkdirAll(worktreePath, 0755)
+}
+
+func (f *uiFakeGitClient) GetBranchPushStatus(ctx context.Context, repoPath, branch string) (gitproxy.BranchPushStatus, error) {
+	if f.pushStatuses != nil {
+		if status, ok := f.pushStatuses[repoPath+"|"+branch]; ok {
+			return status, nil
+		}
+	}
+	return gitproxy.BranchPushStatus{Branch: branch, RemoteRef: "origin/" + branch, IsPushed: true}, nil
 }

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/design.md
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/design.md
@@ -1,0 +1,55 @@
+## Context
+
+`GitProxy.RemoveWorktreeAndBranch` currently removes the worktree and then force-deletes the matching local branch when the branch slug matches the feature directory name. `Engine.DeleteWorktree` calls this for every configured module and the main project. The TUI calls the same engine method after its existing delete confirmation.
+
+Dirty worktree checks protect uncommitted files, but they do not protect committed local work that has not been pushed. The existing branch slug guard prevents deleting the wrong branch, but it does not verify that the branch is recoverable from a remote.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect local branches that would be deleted and are ahead of, or missing from, their remote branch.
+- Require explicit `--allow-unpushed` confirmation in CLI before deleting those branches.
+- Keep TUI's second confirmation before deleting those branches.
+- Keep deletion behavior unchanged when all candidate branches are fully pushed.
+- Keep rollback cleanup from failed create operations working without user prompts.
+
+**Non-Goals:**
+
+- Automatically push branches.
+- Change the feature-name to directory-name slug rule.
+- Protect non-branch detached HEAD worktrees beyond the existing "skip branch delete" behavior.
+- Introduce new Git remotes or infer URLs outside Git's existing local remote configuration.
+
+## Decisions
+
+### Decision 1: Engine-level preflight, not gitproxy-level blocking
+
+Deletion should collect branch risk before removing any worktree. The engine will expose a delete preflight that returns candidate branches whose local commits are not confirmed on the remote. CLI and TUI can then ask the human once before destructive work starts.
+
+Alternative considered: make `RemoveWorktreeAndBranch` refuse to delete unpushed branches. This would also affect rollback paths where newly-created local branches are intentionally cleaned up after a failed create, and it would discover risk one repository at a time after deletion had already started.
+
+### Decision 2: Explicit delete options after confirmation
+
+`DeleteWorktree` keeps the safe default and blocks when unpushed branches exist. A new options-based deletion path allows CLI to pass `AllowUnpushedBranches` only when `--allow-unpushed` is provided, and allows TUI to pass it only after the second confirmation.
+
+Alternative considered: let `--force` bypass the check. Rejected because the current `--force` meaning is limited to dirty checks; silently expanding it to cover committed unpushed work would be surprising.
+
+### Decision 3: Ahead-count push status
+
+Git push status is determined by fetching remotes, resolving the branch upstream when available, otherwise falling back to `origin/<branch>`, and checking the ahead count with `remoteRef..branch`. Ahead count `0` means the local branch is safe to delete. Missing upstream/remote, fetch failure, or ahead count greater than zero means the branch requires confirmation.
+
+Alternative considered: only check whether a remote branch exists. Rejected because a remote branch can exist while local HEAD still contains newer unpushed commits.
+
+### Decision 4: TUI adds a second risk confirmation state
+
+The current TUI delete confirmation remains the first confirmation. After the user confirms deletion, the TUI runs the unpushed-branch preflight. If risk exists, the TUI shows the affected project/modules and requires a second `y` before deletion.
+
+Alternative considered: include all risk details in the original confirmation view. Rejected because the risk list requires Git inspection and may be slow; keeping it after the first confirmation avoids doing network work while merely browsing.
+
+## Risks / Trade-offs
+
+- [Risk] Fetching remotes during delete may add latency. -> Mitigation: only run the check after the user initiates deletion and keep the result list concise.
+- [Risk] Repositories with non-`origin` remotes and no upstream may be treated as unpushed. -> Mitigation: this is conservative and requires confirmation rather than allowing silent deletion.
+- [Risk] CLI users may expect an interactive prompt. -> Mitigation: return `ERR_UNPUSHED_BRANCH` with branch details and tell callers to rerun with `--allow-unpushed`.
+- [Risk] TUI module-management removal also uses branch deletion. -> Mitigation: engine defaults block unpushed module deletion; feature delete gets the richer TUI confirmation in this change.

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/proposal.md
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`modu delete` and TUI deletion remove both worktrees and matching local branches. If a branch has local commits that have not reached a remote branch, deletion can permanently discard work that is not recoverable from the remote.
+
+Deletion already protects dirty worktrees, but clean committed local-only work is still at risk. The delete flow needs an explicit pushed-state check before removing local branches.
+
+## What Changes
+
+- Before deleting a local branch as part of feature or module worktree removal, determine whether the branch is fully pushed to its tracked or remote branch.
+- If every branch that would be removed is already pushed, delete proceeds without extra confirmation.
+- If any branch is not pushed, CLI deletion fails with a dedicated unpushed-branch error unless `--allow-unpushed` is provided.
+- TUI deletion includes a risk confirmation view that lists unpushed branches before executing deletion.
+- `--force` continues to skip dirty checks only; it does not silently bypass unpushed-branch protection.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `cli`: `modu delete` must guard local branch deletion when commits are not pushed and require `--allow-unpushed` to continue.
+- `engine`: delete and module-removal flows must preflight branch push state before destructive removal.
+- `gitproxy`: Git primitives must expose branch push-state inspection for local branches.
+- `tui`: TUI delete must require an additional confirmation when unpushed branches would be removed.
+- `errors`: add a machine-readable error for deletion blocked by unpushed local branches.
+
+## Impact
+
+- `cmd/modu/main.go`: CLI delete confirmation and non-interactive behavior.
+- `internal/engine`: delete preflight orchestration for features and modules.
+- `internal/gitproxy`: branch push-state Git commands and tests.
+- `internal/ui`: risk confirmation state and rendering.
+- `internal/errors` and `internal/output`: error code and formatted failure behavior.
+- Tests in `internal/engine`, `internal/gitproxy`, `internal/ui`, and CLI/output areas.

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/cli/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Delete protects unpushed local branches
+The `modu delete` command SHALL check whether local branches that would be deleted are fully pushed before removing worktrees or local branches.
+
+#### Scenario: All branches are pushed
+- **WHEN** the user runs `modu delete <feature>` and every branch that would be deleted has no local commits ahead of its remote branch
+- **THEN** deletion proceeds without an additional unpushed-branch confirmation
+
+#### Scenario: Delete has unpushed branches without explicit allow flag
+- **WHEN** the user runs `modu delete <feature>` and at least one branch that would be deleted is not fully pushed
+- **THEN** the command fails with `ERR_UNPUSHED_BRANCH` without deleting worktrees or local branches
+- **THEN** the error message tells the user to rerun with `--allow-unpushed` to confirm deletion
+
+#### Scenario: Delete has unpushed branches with explicit allow flag
+- **WHEN** the user runs `modu delete <feature> --allow-unpushed` and at least one branch that would be deleted is not fully pushed
+- **THEN** deletion proceeds without interactive confirmation
+
+#### Scenario: Force does not bypass unpushed protection
+- **WHEN** the user runs `modu delete <feature> --force` and at least one branch that would be deleted is not fully pushed
+- **THEN** the command fails with `ERR_UNPUSHED_BRANCH` unless `--allow-unpushed` is also provided

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/engine/spec.md
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/engine/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Engine preflights unpushed branch deletion
+The engine SHALL identify all local branches that would be deleted by a feature deletion before removing any worktree.
+
+#### Scenario: Candidate branch is fully pushed
+- **WHEN** a candidate branch has no local commits ahead of its remote branch
+- **THEN** the engine treats that branch as safe for deletion
+
+#### Scenario: Candidate branch is not fully pushed
+- **WHEN** a candidate branch has no remote branch, no usable upstream, a failed push-state lookup, or local commits ahead of its remote branch
+- **THEN** the engine reports that branch as requiring confirmation before deletion
+
+#### Scenario: Delete without confirmation has unpushed branches
+- **WHEN** `DeleteWorktree` is called for a feature with unpushed branch candidates
+- **THEN** the engine returns `ERR_UNPUSHED_BRANCH` without removing worktrees or local branches
+
+#### Scenario: Delete with explicit confirmation has unpushed branches
+- **WHEN** an options-based delete call explicitly allows unpushed branch deletion
+- **THEN** the engine may remove the worktrees and matching local branches after normal dirty-check rules pass
+
+#### Scenario: Branch is not a deletion candidate
+- **WHEN** a worktree is detached, has no readable branch, or its branch slug does not match the feature directory name
+- **THEN** the engine does not require unpushed-branch confirmation for that worktree because the branch will not be deleted

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/errors/spec.md
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/errors/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Unpushed branch deletion error
+The system SHALL expose a machine-readable error code for deletion blocked by unpushed local branches.
+
+#### Scenario: Error code for blocked deletion
+- **WHEN** deletion is blocked because one or more local branches are not fully pushed
+- **THEN** the returned error code is `ERR_UNPUSHED_BRANCH`
+
+#### Scenario: JSON output includes branch details
+- **WHEN** JSON output is requested for a delete operation blocked by unpushed branches
+- **THEN** the error response includes enough detail to identify the affected repositories, worktrees, branches, and reasons

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/gitproxy/spec.md
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/gitproxy/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Branch push state inspection
+GitProxy SHALL expose an operation that determines whether a local branch is fully contained in a remote branch before deletion.
+
+#### Scenario: Branch has no commits ahead of remote
+- **WHEN** the local branch resolves to a remote ref and `remote..branch` has an ahead count of zero
+- **THEN** GitProxy reports the branch as pushed
+
+#### Scenario: Branch is ahead of remote
+- **WHEN** the local branch resolves to a remote ref and `remote..branch` has an ahead count greater than zero
+- **THEN** GitProxy reports the branch as not pushed with the ahead count
+
+#### Scenario: Remote branch cannot be resolved
+- **WHEN** the local branch has no upstream and no fallback `origin/<branch>` remote ref
+- **THEN** GitProxy reports the branch as not pushed
+
+#### Scenario: Push-state Git command fails
+- **WHEN** fetching or push-state inspection fails
+- **THEN** GitProxy returns a contextual error and the engine treats the branch as requiring confirmation

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/tui/spec.md
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/specs/tui/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: TUI confirms unpushed branch deletion
+The TUI SHALL require an additional confirmation before deleting a feature when the delete operation would remove local branches that are not fully pushed.
+
+#### Scenario: Delete has no unpushed branches
+- **WHEN** the user confirms feature deletion and all branch candidates are fully pushed
+- **THEN** the TUI deletes the feature and returns to the refreshed list view
+
+#### Scenario: Delete has unpushed branches
+- **WHEN** the user confirms feature deletion and at least one branch candidate is not fully pushed
+- **THEN** the TUI displays a second confirmation view listing the affected project or module branches
+
+#### Scenario: User confirms unpushed deletion
+- **WHEN** the unpushed-branch confirmation view is visible and the user presses `y` or Enter
+- **THEN** the TUI deletes the feature with explicit unpushed-branch permission and refreshes the list
+
+#### Scenario: User cancels unpushed deletion
+- **WHEN** the unpushed-branch confirmation view is visible and the user presses `n` or Esc
+- **THEN** the TUI cancels deletion and returns to the list without removing worktrees or branches

--- a/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/tasks.md
+++ b/openspec/changes/archive/2026-05-16-protect-delete-unpushed-branches/tasks.md
@@ -1,0 +1,30 @@
+## 1. Git Push-State Primitive
+
+- [x] 1.1 Add branch push-state types and `GitClient` method for checking whether a local branch is fully pushed.
+- [x] 1.2 Implement GitProxy push-state inspection with upstream resolution, `origin/<branch>` fallback, ahead-count detection, and contextual errors.
+- [x] 1.3 Add gitproxy tests for pushed, ahead, and missing-remote branch states.
+
+## 2. Engine Delete Preflight
+
+- [x] 2.1 Add delete-branch risk types and an engine method that collects unpushed branch candidates for feature deletion.
+- [x] 2.2 Add options-based feature deletion that blocks unpushed branches by default and allows them only after explicit confirmation.
+- [x] 2.3 Preserve existing dirty-check and branch-slug skip behavior while avoiding partial deletion when unpushed branches exist.
+- [x] 2.4 Add engine tests for safe deletion, blocked unpushed deletion, confirmed unpushed deletion, and non-candidate branches.
+
+## 3. CLI Behavior
+
+- [x] 3.1 Add `ERR_UNPUSHED_BRANCH` error code and formatted branch details for blocked deletion.
+- [x] 3.2 Update `modu delete` to fail with `ERR_UNPUSHED_BRANCH` when unpushed branches exist.
+- [x] 3.3 Add `--allow-unpushed` so users can explicitly confirm deletion without an interactive prompt.
+
+## 4. TUI Behavior
+
+- [x] 4.1 Add TUI state for unpushed-branch risk confirmation with concise branch list rendering.
+- [x] 4.2 Update feature deletion flow to preflight after the normal delete confirmation, then delete directly or show the risk confirmation.
+- [x] 4.3 Add TUI tests for risk view rendering, confirm-to-delete, and cancel-without-delete behavior.
+
+## 5. Verification
+
+- [x] 5.1 Run gofmt on modified Go files.
+- [x] 5.2 Run targeted Go tests for gitproxy, engine, CLI/output, and TUI packages.
+- [x] 5.3 Run `go test ./...` if targeted tests pass.

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -17,7 +17,7 @@
 |------|------|------|
 | `modu` | - | 无子命令时进入 TUI |
 | `modu create` | `<feature> [--base <branch>] [--modules m1,m2]` | 并发创建基于基准分支的 worktree；可指定部分模块；feature 已存在时可继续添加模块 |
-| `modu delete` | `<feature> [-f\|--force]` | 删除 worktree；默认脏检查，`--force` 跳过 |
+| `modu delete` | `<feature> [-f\|--force] [--allow-unpushed]` | 删除 worktree；默认脏检查，`--force` 跳过脏检查，`--allow-unpushed` 显式允许删除未推送本地分支 |
 | `modu list` | `[-v\|--verbose] [-a\|--all]` | 列出所有 worktree；verbose 显示模块、分支、状态；-a 显示主项目及模块分支 |
 | `modu info` | `<feature>` | 查看指定 feature 详情 |
 | `modu init` | `[--scan]` | 并发克隆配置中的仓库；`--scan` 可先扫描发现模块再初始化 |
@@ -36,6 +36,28 @@
 
 - 子命令存在时始终走 CLI，不走 TUI。
 - JSON 输出（`-o json`）时，成功/失败结构需符合 [errors 规范](./../errors/spec.md) 中的机器输出协议。
+
+## Requirements
+
+### Requirement: Delete protects unpushed local branches
+The `modu delete` command SHALL check whether local branches that would be deleted are fully pushed before removing worktrees or local branches.
+
+#### Scenario: All branches are pushed
+- **WHEN** the user runs `modu delete <feature>` and every branch that would be deleted has no local commits ahead of its remote branch
+- **THEN** deletion proceeds without an additional unpushed-branch confirmation
+
+#### Scenario: Delete has unpushed branches without explicit allow flag
+- **WHEN** the user runs `modu delete <feature>` and at least one branch that would be deleted is not fully pushed
+- **THEN** the command fails with `ERR_UNPUSHED_BRANCH` without deleting worktrees or local branches
+- **THEN** the error message tells the user to rerun with `--allow-unpushed` to confirm deletion
+
+#### Scenario: Delete has unpushed branches with explicit allow flag
+- **WHEN** the user runs `modu delete <feature> --allow-unpushed` and at least one branch that would be deleted is not fully pushed
+- **THEN** deletion proceeds without interactive confirmation
+
+#### Scenario: Force does not bypass unpushed protection
+- **WHEN** the user runs `modu delete <feature> --force` and at least one branch that would be deleted is not fully pushed
+- **THEN** the command fails with `ERR_UNPUSHED_BRANCH` unless `--allow-unpushed` is also provided
 
 ## 与代码的对应
 

--- a/openspec/specs/engine/spec.md
+++ b/openspec/specs/engine/spec.md
@@ -25,6 +25,29 @@
 2. 若未使用 `--force` 且 `Config.StrictDirty` 为 true：构建 `WorktreeEnv` 时仅包含 **配置内模块** 子目录，调用 **CheckDirty**；若有 dirty 模块，返回 `ERR_DIRTY_WORKTREE`。
 3. 仅对 **配置内模块** 依次执行 `RemoveWorktreeAndBranch(ctx, repoPath, modulePath, dirName)`，再对主项目执行 `RemoveWorktreeAndBranch(ctx, workspace, mainProjectPath, dirName)`，最后 `os.RemoveAll(featurePath)`。`dirName` 为 `featureToDirName(feature)`，供 gitproxy 校验「当前分支 slug」与目录名一致后再删分支。不对非配置目录单独调用 RemoveWorktreeAndBranch。
 
+### Requirement: Engine preflights unpushed branch deletion
+The engine SHALL identify all local branches that would be deleted by a feature deletion before removing any worktree.
+
+#### Scenario: Candidate branch is fully pushed
+- **WHEN** a candidate branch has no local commits ahead of its remote branch
+- **THEN** the engine treats that branch as safe for deletion
+
+#### Scenario: Candidate branch is not fully pushed
+- **WHEN** a candidate branch has no remote branch, no usable upstream, a failed push-state lookup, or local commits ahead of its remote branch
+- **THEN** the engine reports that branch as requiring confirmation before deletion
+
+#### Scenario: Delete without confirmation has unpushed branches
+- **WHEN** `DeleteWorktree` is called for a feature with unpushed branch candidates
+- **THEN** the engine returns `ERR_UNPUSHED_BRANCH` without removing worktrees or local branches
+
+#### Scenario: Delete with explicit confirmation has unpushed branches
+- **WHEN** an options-based delete call explicitly allows unpushed branch deletion
+- **THEN** the engine may remove the worktrees and matching local branches after normal dirty-check rules pass
+
+#### Scenario: Branch is not a deletion candidate
+- **WHEN** a worktree is detached, has no readable branch, or its branch slug does not match the feature directory name
+- **THEN** the engine does not require unpushed-branch confirmation for that worktree because the branch will not be deleted
+
 ## CheckDirty
 
 - 输入：`WorktreeEnv`（含各模块 Path）。

--- a/openspec/specs/errors/spec.md
+++ b/openspec/specs/errors/spec.md
@@ -18,6 +18,7 @@
 | `ERR_FEATURE_NOT_FOUND` | Feature 目录不存在 |
 | `ERR_MODULE_NOT_FOUND` | 模块路径不存在（如 git status 时目录缺失） |
 | `ERR_INVALID_OPERATION` | 非法操作（预留） |
+| `ERR_UNPUSHED_BRANCH` | 删除被未推送本地分支保护拦截 |
 
 ## 错误包装
 
@@ -76,6 +77,20 @@
 | Git 失败 | 带出完整错误信息 | 界面提示并允许重试 |
 | 并发部分失败 | 打印成功/失败汇总 | 显示失败模块列表 |
 | 脏检查失败 | 退出码非 0 | 弹窗阻止删除 |
+| 未推送本地分支 | 返回 `ERR_UNPUSHED_BRANCH`；用户通过 `--allow-unpushed` 显式确认后才删除 | 二次确认后才删除 |
+
+## Requirements
+
+### Requirement: Unpushed branch deletion error
+The system SHALL expose a machine-readable error code for deletion blocked by unpushed local branches.
+
+#### Scenario: Error code for blocked deletion
+- **WHEN** deletion is blocked because one or more local branches are not fully pushed
+- **THEN** the returned error code is `ERR_UNPUSHED_BRANCH`
+
+#### Scenario: JSON output includes branch details
+- **WHEN** JSON output is requested for a delete operation blocked by unpushed branches
+- **THEN** the error response includes enough detail to identify the affected repositories, worktrees, branches, and reasons
 
 ## 与代码的对应
 

--- a/openspec/specs/gitproxy/spec.md
+++ b/openspec/specs/gitproxy/spec.md
@@ -14,6 +14,7 @@
 - **RemoveWorktree(ctx, path)**：`git worktree remove <path>`；若 remove 失败可回退为 `os.RemoveAll(path)`（实现可选）。
 - **RemoveWorktreeAndBranch(ctx, repoPath, worktreePath, featureDirName)**：在移除 worktree **之前**对 `worktreePath` 调用 `GetStatus` 取得当前检出分支；仅当将该分支名中的 `/` 全部替换为 `-` 后的字符串与 `featureDirName`（与 `worktree-root` 下该 feature 的目录 basename 一致）相同时，才在 `repoPath` 上对该分支执行 `git branch -D`。若无法读状态、detached HEAD（`HEAD`）、或不一致，则仍执行 worktree remove / prune，但**不删除分支**（防误删）。`featureDirName` 规则与引擎侧「分支名 → 目录名」转换一致（`/ → -`）。
 - **FetchAndSwitchBranch(ctx, repoPath, branch)**：在 repoPath 仓库中先执行 `git fetch origin` 拉取最新，再执行 `git checkout <branch>` 切换到指定分支；若分支不存在返回错误；若切换失败返回带 `ERR_GIT_EXEC` 的上下文错误。
+- **GetBranchPushStatus(ctx, repoPath, branch)**：检查本地分支是否已完整包含在远端分支中；优先使用 upstream，无法解析时回退 `origin/<branch>`。
 
 ## Status 解析
 
@@ -23,6 +24,27 @@
 ## 错误约定
 
 - 所有返回错误须包含：操作类型、路径/仓库/分支等上下文、原始 stderr（或摘要），并 wrap `ERR_GIT_EXEC` 或 `ERR_MODULE_NOT_FOUND`。
+
+## Requirements
+
+### Requirement: Branch push state inspection
+GitProxy SHALL expose an operation that determines whether a local branch is fully contained in a remote branch before deletion.
+
+#### Scenario: Branch has no commits ahead of remote
+- **WHEN** the local branch resolves to a remote ref and `remote..branch` has an ahead count of zero
+- **THEN** GitProxy reports the branch as pushed
+
+#### Scenario: Branch is ahead of remote
+- **WHEN** the local branch resolves to a remote ref and `remote..branch` has an ahead count greater than zero
+- **THEN** GitProxy reports the branch as not pushed with the ahead count
+
+#### Scenario: Remote branch cannot be resolved
+- **WHEN** the local branch has no upstream and no fallback `origin/<branch>` remote ref
+- **THEN** GitProxy reports the branch as not pushed
+
+#### Scenario: Push-state Git command fails
+- **WHEN** fetching or push-state inspection fails
+- **THEN** GitProxy returns a contextual error and the engine treats the branch as requiring confirmation
 
 ## 与代码的对应
 

--- a/openspec/specs/tui/spec.md
+++ b/openspec/specs/tui/spec.md
@@ -108,6 +108,25 @@
 - **WHEN** 用户在列表视图按 d
 - **THEN** TUI 进入删除确认状态，显示待删除的特征名
 
+### Requirement: TUI confirms unpushed branch deletion
+The TUI SHALL require an additional confirmation before deleting a feature when the delete operation would remove local branches that are not fully pushed.
+
+#### Scenario: Delete has no unpushed branches
+- **WHEN** the user confirms feature deletion and all branch candidates are fully pushed
+- **THEN** the TUI deletes the feature and returns to the refreshed list view
+
+#### Scenario: Delete has unpushed branches
+- **WHEN** the user confirms feature deletion and at least one branch candidate is not fully pushed
+- **THEN** the TUI displays a second confirmation view listing the affected project or module branches
+
+#### Scenario: User confirms unpushed deletion
+- **WHEN** the unpushed-branch confirmation view is visible and the user presses `y` or Enter
+- **THEN** the TUI deletes the feature with explicit unpushed-branch permission and refreshes the list
+
+#### Scenario: User cancels unpushed deletion
+- **WHEN** the unpushed-branch confirmation view is visible and the user presses `n` or Esc
+- **THEN** the TUI cancels deletion and returns to the list without removing worktrees or branches
+
 ### Requirement: TUI feature creation entry
 The TUI SHALL provide a list-view action for starting feature creation without changing existing list navigation, open, update, copy, module-management, delete, or quit shortcuts.
 


### PR DESCRIPTION
## Summary
- add pushed-state checks before deleting worktree branches
- block unpushed local branches by default and require confirmation in CLI/TUI
- archive and sync OpenSpec docs for the change

## Verification
- env GOCACHE=/private/tmp/modu-go-build-cache pre-commit run --all-files
- go test -count=1 ./...
- openspec validate protect-delete-unpushed-branches --type change --strict