### PR TITLE
[codex] Use config default base for create

### DIFF
--- a/cmd/modu/main.go
+++ b/cmd/modu/main.go
@@ -267,10 +267,10 @@ func loadConfig() *engine.Engine {
 
 func runCreate(cmd *cobra.Command, args []string) {
 	feature := args[0]
-	base, _ := cmd.Flags().GetString("base")
 	modules, _ := cmd.Flags().GetStringSlice("modules")
 
 	eng := loadConfig()
+	base := resolveCreateBase(cmd, eng.Config)
 
 	// 检查 feature 是否已存在
 	featurePath := filepath.Join(eng.Config.WorktreeRoot, feature)
@@ -403,6 +403,14 @@ func runCreate(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Print(formatter.FormatCreateResponse(feature, []output.Result{}, nil))
+}
+
+func resolveCreateBase(cmd *cobra.Command, cfg *config.Config) string {
+	base, _ := cmd.Flags().GetString("base")
+	if !cmd.Flags().Changed("base") && cfg.DefaultBase != "" {
+		return cfg.DefaultBase
+	}
+	return base
 }
 
 func runDelete(cmd *cobra.Command, args []string) {

--- a/cmd/modu/main_test.go
+++ b/cmd/modu/main_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/qimaotech/modu/internal/config"
+	"github.com/spf13/cobra"
 )
 
 func TestIsInteractiveTerminal(t *testing.T) {
@@ -196,6 +199,39 @@ func TestRunCreate_FilterExistingModules(t *testing.T) {
 			t.Errorf("expected filtered[0] 'module3', got %s", filtered[0])
 		}
 	})
+}
+
+func TestResolveCreateBase(t *testing.T) {
+	t.Run("未显式指定base时使用配置默认分支", func(t *testing.T) {
+		cmd := newCreateBaseTestCommand()
+		cfg := &config.Config{DefaultBase: "master"}
+
+		base := resolveCreateBase(cmd, cfg)
+
+		if base != "master" {
+			t.Errorf("expected base master, got %s", base)
+		}
+	})
+
+	t.Run("显式指定base时覆盖配置默认分支", func(t *testing.T) {
+		cmd := newCreateBaseTestCommand()
+		if err := cmd.Flags().Set("base", "release"); err != nil {
+			t.Fatalf("set base flag: %v", err)
+		}
+		cfg := &config.Config{DefaultBase: "master"}
+
+		base := resolveCreateBase(cmd, cfg)
+
+		if base != "release" {
+			t.Errorf("expected base release, got %s", base)
+		}
+	})
+}
+
+func newCreateBaseTestCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("base", "develop", "基准分支")
+	return cmd
 }
 
 // 辅助函数和测试用结构体


### PR DESCRIPTION
## Summary

- Make `modu create` use `.modu.yaml` `default-base` when `--base` is not explicitly passed.
- Keep explicit `--base` behavior as an override.
- Add focused tests for both paths.

## Root Cause

`modu create` defined the `--base` flag with a hard-coded default of `develop` and passed that flag value directly to `CreateWorktree`. In repositories whose configured default base is `master`, this made Git run `worktree add ... develop`, which fails when `develop` is not a valid ref.

## Validation

- `go test ./cmd/modu`
- `go test ./cmd/modu ./internal/engine ./internal/gitproxy`
- `go build -o modu ./cmd/modu && go test ./...`
